### PR TITLE
feat: add --ignore cmdline option in publish

### DIFF
--- a/messages/edge_applications/messages.go
+++ b/messages/edge_applications/messages.go
@@ -72,7 +72,7 @@ var (
 	EdgeApplicationsRulesEngineSuccessful              = "Created Rules Engine for web application"
 	EdgeApplicationsPublishFlagHelp                    = "Displays more information about the publish subcommand"
 	EdgeApplicationsPublishPropagation                 = "Content is being propagated to all Azion POPs and it might take a few minutes for all edges to be up to date\n"
-	EdgeApplicationPublishIgnoreFlag                   = "Files and directories to ignore when publishing the application"
+	EdgeApplicationPublishIgnoreFlag                   = "Files and directories to ignore when publishing the application; follows the gitignore pattern"
 
 	//CRUD
 	//list cmd

--- a/messages/edge_applications/messages.go
+++ b/messages/edge_applications/messages.go
@@ -72,6 +72,7 @@ var (
 	EdgeApplicationsRulesEngineSuccessful              = "Created Rules Engine for web application"
 	EdgeApplicationsPublishFlagHelp                    = "Displays more information about the publish subcommand"
 	EdgeApplicationsPublishPropagation                 = "Content is being propagated to all Azion POPs and it might take a few minutes for all edges to be up to date\n"
+	EdgeApplicationPublishIgnoreFlag                   = "Files and directories to ignore when publishing the application"
 
 	//CRUD
 	//list cmd

--- a/pkg/cmd/edge_applications/publish/get_file_list.go
+++ b/pkg/cmd/edge_applications/publish/get_file_list.go
@@ -1,0 +1,52 @@
+package publish
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// Return a list of files inside the given directory, ignoring the given globs
+func (cmd *PublishCmd) getFileList(root string, ignore_globs []string) ([]string, error) {
+	var files []string
+
+	// parse ignore globs with gitignore.Pattern.ParsePattern
+	var patterns []gitignore.Pattern
+	for _, glob := range ignore_globs {
+		pattern := gitignore.ParsePattern(glob, []string{})
+		patterns = append(patterns, pattern)
+	}
+	matcher := gitignore.NewMatcher(patterns)
+
+	err := cmd.FilepathWalk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// use relative path to compare to ignore globs
+		rel_path, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		rel_path_list := strings.Split(rel_path, string(filepath.Separator))
+		ignore_matched := matcher.Match(rel_path_list, info.IsDir())
+		if !ignore_matched {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/pkg/cmd/edge_applications/publish/get_file_list_test.go
+++ b/pkg/cmd/edge_applications/publish/get_file_list_test.go
@@ -1,0 +1,94 @@
+package publish
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aziontech/azion-cli/pkg/testutils"
+)
+
+func TestPublishGetFileList(t *testing.T) {
+	t.Run("ignore specified files", func(t *testing.T) {
+		files := []string{
+			"index.html",
+			"ignore.js",
+			"some/",
+			"some/file.html",
+			"some/ignore.js",
+			"ignore/",
+			"ignore/file.html",
+			"ignore/file.txt",
+			".git/",
+			".git/ignore.txt",
+			".git/ignore_too.txt",
+		}
+		globs := []string{
+			"ignore/*.html",
+			".git",
+			"*.js",
+		}
+		ignored_files := []string{
+			"ignore.js",
+			"some/ignore.js",
+			"ignore/file.html",
+			".git/ignore.txt",
+			".git/ignore_too.txt",
+		}
+
+		f, _, _ := testutils.NewFactory(nil)
+
+		cmd := NewPublishCmd(f)
+
+		cmd.FilepathWalk = func(root string, fn filepath.WalkFunc) error {
+			for _, file := range files {
+				info := MockedFileInfo{isDir: strings.HasSuffix(file, "/")}
+				file = strings.TrimSuffix(file, "/")
+
+				_ = fn(file, info, nil)
+			}
+			return nil
+		}
+
+		filelist, _ := cmd.getFileList("", globs)
+
+		for _, ignored_file := range ignored_files {
+			for _, file := range filelist {
+				if file == ignored_file {
+					t.Errorf("file %s should be ignored", file)
+				}
+			}
+		}
+	})
+}
+
+type MockedFileInfo struct {
+	isDir bool
+}
+
+func (m MockedFileInfo) IsDir() bool {
+	return m.isDir
+}
+
+func (m MockedFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (m MockedFileInfo) Mode() os.FileMode {
+	return 0
+}
+
+func (m MockedFileInfo) Name() string {
+	return ""
+}
+
+func (m MockedFileInfo) Size() int64 {
+	return 0
+}
+
+func (m MockedFileInfo) Sys() interface{} {
+	var sys interface{}
+	return sys
+}

--- a/pkg/cmd/edge_applications/publish/publish.go
+++ b/pkg/cmd/edge_applications/publish/publish.go
@@ -90,7 +90,7 @@ func NewCobraCmd(publish *PublishCmd) *cobra.Command {
 	}
 	publishCmd.Flags().BoolP("help", "h", false, msg.EdgeApplicationsPublishFlagHelp)
 	publishCmd.Flags().StringVar(&Path, "path", "public", msg.EdgeApplicationPublishPathFlag)
-	publishCmd.Flags().StringSliceVarP(&Ignore, "ignore", "i", []string{}, msg.EdgeApplicationPublishIgnoreFlag)
+	publishCmd.Flags().StringSliceVar(&Ignore, "ignore", []string{}, msg.EdgeApplicationPublishIgnoreFlag)
 	return publishCmd
 }
 
@@ -732,7 +732,7 @@ func publishStatic(cmd *PublishCmd, f *cmdutil.Factory) error {
 	if err != nil {
 		return err
 	}
-	
+
 	// upload the page static
 	files, err := cmd.getFileList(Path, Ignore)
 	if err != nil {


### PR DESCRIPTION
This command line option allows one to specify globs to ignore publishing of matching files. The glob pattern is the same as of gitignore.