### PR TITLE
chore: fix examples and command usages

### DIFF
--- a/messages/create/domains/messages.go
+++ b/messages/create/domains/messages.go
@@ -1,7 +1,7 @@
 package domains
 
 var (
-	Usage                    = "domains [flags]"
+	Usage                    = "domain"
 	ShortDescription         = "Creates a new domain"
 	LongDescription          = "Creates a domain based on given attributes to be used with edge applications"
 	FlagName                 = "The domain's name"

--- a/messages/create/edge_application/messages.go
+++ b/messages/create/edge_application/messages.go
@@ -25,5 +25,4 @@ var (
 	FlagWebsocket                      = "Allows you to establish the WebSocket communication protocol between your origin and your users under the reverse proxy architecture."
 	FlagBrowserCacheSettingsMaximumTtl = "Defines the maximum time to live (TTL) of cached resources in the browser. It can be used to set a time limit for how long resources can be cached in the browser."
 	FlagCdnCacheSettingsMaximumTtl     = "Defines the maximum time to live (TTL) of cached resources in the CDN. It can be used to set a time limit for how long resources can be cached on the CDN servers."
-
 )

--- a/messages/create/rules_engine/messages.go
+++ b/messages/create/rules_engine/messages.go
@@ -1,7 +1,7 @@
 package rules_engine
 
 var (
-	Usage                 = "rules-engine [flags]"
+	Usage                 = "rules-engine"
 	ShortDescription      = "Creates a rule in Rules Engine"
 	LongDescription       = "Creates a rule in Rules Engine based on given attributes to be used in edge applications"
 	FlagEdgeApplicationID = "Unique identifier for an edge application"

--- a/messages/delete/domains/messages.go
+++ b/messages/delete/domains/messages.go
@@ -1,7 +1,7 @@
 package domains
 
 var (
-	Usage            = "domains"
+	Usage            = "domain"
 	ShortDescription = "Removes a domain"
 	LongDescription  = "Removes a domain from the Domains library based on a given ID"
 	OutputSuccess    = "Domain %d was successfully deleted\n"

--- a/messages/describe/domains/messages.go
+++ b/messages/describe/domains/messages.go
@@ -1,7 +1,7 @@
 package domains
 
 var (
-	Usage            = "domains --domain-id <domain_id> [flags]"
+	Usage            = "domain"
 	ShortDescription = "Returns the domain data"
 	LongDescription  = "Displays information about the domain via a given ID to show the application’s attributes in detail"
 	FlagOut          = "Exports the output to the given <file_path/file_name.ext>"

--- a/messages/describe/edge_applications/messages.go
+++ b/messages/describe/edge_applications/messages.go
@@ -1,7 +1,7 @@
 package edge_applications
 
 var (
-	Usage            = "edge-application --application-id <application_id> [flags]"
+	Usage            = "edge-application"
 	ShortDescription = "Returns the Edge Application data"
 	LongDescription  = "Displays information about the Edge Application via a given ID to show the application’s attributes in detail"
 	FlagOut          = "Exports the output to the given <file_path/file_name.ext>"

--- a/messages/list/domains/messages.go
+++ b/messages/list/domains/messages.go
@@ -1,8 +1,8 @@
 package domains
 
 var (
-	DomainsListUsage            = "domains"
-	DomainsListShortDescription = "Displays your domains"
-	DomainsListLongDescription  = "Displays all your domain references to your edge locations"
-	DomainsListHelpFlag         = "Displays more information about the list domain command"
+	Usage            = "domain"
+	ShortDescription = "Displays your domains"
+	LongDescription  = "Displays all your domain references to your edge locations"
+	HelpFlag         = "Displays more information about the list domain command"
 )

--- a/messages/list/edge_applications/messages.go
+++ b/messages/list/edge_applications/messages.go
@@ -1,8 +1,8 @@
 package edge_applications
 
 var (
-	ListUsage            = "edge-application [flags]"
-	ListShortDescription = "Displays your edge applications in a list"
-	ListLongDescription  = "Displays all your edge applications in a list"
-	ListHelpFlag         = "Displays more information about the list command"
+	Usage            = "edge-application"
+	ShortDescription = "Displays your edge applications in a list"
+	LongDescription  = "Displays all your edge applications in a list"
+	HelpFlag         = "Displays more information about the list command"
 )

--- a/messages/update/domains/messages.go
+++ b/messages/update/domains/messages.go
@@ -1,7 +1,7 @@
 package domains
 
 var (
-	Usage                    = "domains --domain-id <domain_id> [flags]"
+	Usage                    = "domain"
 	ShortDescription         = "Updates a domain"
 	LongDescription          = "Updates a domain's name and other attributes based on a given ID"
 	FlagDomainID             = "The '--domain-id'"

--- a/messages/update/edge_application/messages.go
+++ b/messages/update/edge_application/messages.go
@@ -1,7 +1,7 @@
 package edge_application
 
 var (
-	Usage                       = "edge-application --id <application_id> [flags]"
+	Usage                       = "edge-application"
 	ShortDescription            = "Modifies an edge application"
 	LongDescription             = "Modifies an edge application's name, activity status, and other attributes based on the given ID"
 	FlagID                      = "The edge application's id"

--- a/pkg/cmd/create/domains/domains.go
+++ b/pkg/cmd/create/domains/domains.go
@@ -37,9 +37,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azion create domains --application-id 1231 --name domainName --cnames "asdf.com,asdfsdf.com,asdfd.com" --cname-access-only false
-        $ azion create domains --name withargs --application-id 1231 --active true
-        $ azion create domains --in "create.json"
+        $ azion create domain --application-id 1231 --name domainName --cnames "asdf.com,asdfsdf.com,asdfd.com" --cname-access-only false
+        $ azion create domain --name withargs --application-id 1231 --active true
+        $ azion create domain --in "create.json"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			request := new(api.CreateRequest)

--- a/pkg/cmd/create/edge_applications/edge_application.go
+++ b/pkg/cmd/create/edge_applications/edge_application.go
@@ -19,9 +19,9 @@ import (
 )
 
 const example = `
-        $ azion create edge-applications --name "naruno"
-        $ azion create edge-applications --in create.json
-        $ json example "create.json": 
+        $ azion create edge-application --name "naruno"
+        $ azion create edge-application --in create.json
+        $ json example to be used with '--in flag' "create.json": 
         {
             "name": "New Edge Application",
             "delivery_protocol": "http",

--- a/pkg/cmd/delete/domains/domains.go
+++ b/pkg/cmd/delete/domains/domains.go
@@ -24,7 +24,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		$ azion delete domains --domain-id 1234
+		$ azion delete domain --domain-id 1234
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/pkg/cmd/delete/edge_application/edge_application.go
+++ b/pkg/cmd/delete/edge_application/edge_application.go
@@ -51,7 +51,7 @@ func NewCobraCmd(delete *DeleteCmd) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		$ azion delete edge-application --id 1234
+		$ azion delete edge-application --application-id 1234
 		$ azion delete edge-application --cascade
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,7 +59,7 @@ func NewCobraCmd(delete *DeleteCmd) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64Var(&application_id, "id", 0, msg.FlagId)
+	cmd.Flags().Int64Var(&application_id, "application-id", 0, msg.FlagId)
 	cmd.Flags().Bool("cascade", true, msg.CascadeFlag)
 	cmd.Flags().BoolP("help", "h", false, msg.HelpFlag)
 
@@ -109,7 +109,7 @@ func (del *DeleteCmd) run(cmd *cobra.Command, application_id int64) error {
 
 	}
 
-	if !cmd.Flags().Changed("id") {
+	if !cmd.Flags().Changed("application-id") {
 		qs := []*survey.Question{
 			{
 				Name:     "id",

--- a/pkg/cmd/delete/edge_application/edge_application_test.go
+++ b/pkg/cmd/delete/edge_application/edge_application_test.go
@@ -28,7 +28,7 @@ func TestCreate(t *testing.T) {
 		f, stdout, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.SetArgs([]string{"--id", "1234"})
+		cmd.SetArgs([]string{"--application-id", "1234"})
 
 		_, err := cmd.ExecuteC()
 		require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestCreate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"--id", "1234"})
+		cmd.SetArgs([]string{"--application-id", "1234"})
 
 		_, err := cmd.ExecuteC()
 		require.Error(t, err)

--- a/pkg/cmd/delete/rules_engine/rules_engine.go
+++ b/pkg/cmd/delete/rules_engine/rules_engine.go
@@ -26,7 +26,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		$ azion delete rules-engine --id 1234 --application-id 99887766 --phase request
+		$ azion delete rules-engine --rule-id 1234 --application-id 99887766 --phase request
 		$ azion delete rules-engine
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/describe/domains/domains.go
+++ b/pkg/cmd/describe/domains/domains.go
@@ -29,9 +29,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azion describe domains --domain-id 4312
-        $ azion describe domains --domain-id 1337 --out "./tmp/test.json" --format json
-        $ azion describe domains --domain-id 1337 --format json
+        $ azion describe domain --domain-id 4312
+        $ azion describe domain --domain-id 1337 --out "./tmp/test.json" --format json
+        $ azion describe domain --domain-id 1337 --format json
         `),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !cmd.Flags().Changed("domain-id") {

--- a/pkg/cmd/describe/edge_applications/edge_applications.go
+++ b/pkg/cmd/describe/edge_applications/edge_applications.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/MaxwelMazur/tablecli"
 	msg "github.com/aziontech/azion-cli/messages/describe/edge_applications"
@@ -13,7 +15,6 @@ import (
 	"github.com/aziontech/azion-cli/utils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
@@ -26,13 +27,13 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-        $ azion describe edge-application --id 4312
-        $ azion describe edge-application --id 1337 --out "./tmp/test.json"
-        $ azion describe edge-application --id 1337 --format json
+        $ azion describe edge-application --application-id 4312
+        $ azion describe edge-application --application-id 1337 --out "./tmp/test.json"
+        $ azion describe edge-application --application-id 1337 --format json
         `),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 
-			if !cmd.Flags().Changed("id") {
+			if !cmd.Flags().Changed("application-id") {
 				answer, err := utils.AskInput(msg.AskInputApplicationID)
 				if err != nil {
 					return err
@@ -72,7 +73,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&applicationID, "id", "", msg.FlagId)
+	cmd.Flags().StringVar(&applicationID, "application-id", "", msg.FlagId)
 	cmd.Flags().StringVar(&opts.OutPath, "out", "", msg.FlagOut)
 	cmd.Flags().StringVar(&opts.Format, "format", "", msg.FlagFormat)
 	cmd.Flags().BoolP("help", "h", false, msg.HelpFlag)

--- a/pkg/cmd/describe/edge_applications/edge_applications_test.go
+++ b/pkg/cmd/describe/edge_applications/edge_applications_test.go
@@ -1,14 +1,15 @@
 package edge_applications
 
 import (
+	"net/http"
+	"os"
+	"testing"
+
 	"github.com/aziontech/azion-cli/pkg/httpmock"
 	"github.com/aziontech/azion-cli/pkg/logger"
 	"github.com/aziontech/azion-cli/pkg/testutils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
-	"net/http"
-	"os"
-	"testing"
 )
 
 func TestDescribe(t *testing.T) {
@@ -26,7 +27,7 @@ func TestDescribe(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"--id", "1232132135"})
+		cmd.SetArgs([]string{"--application-id", "1232132135"})
 
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -43,7 +44,7 @@ func TestDescribe(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"--id", "1234"})
+		cmd.SetArgs([]string{"--application-id", "1234"})
 
 		err := cmd.Execute()
 
@@ -81,7 +82,7 @@ func TestDescribe(t *testing.T) {
 
 		path := "./out.json"
 
-		cmd.SetArgs([]string{"--id", "123", "--out", path})
+		cmd.SetArgs([]string{"--application-id", "123", "--out", path})
 
 		err := cmd.Execute()
 		if err != nil {

--- a/pkg/cmd/describe/rules_engine/rules_engine.go
+++ b/pkg/cmd/describe/rules_engine/rules_engine.go
@@ -37,7 +37,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-      $ azion describe rules-engine  --application-id 1673635839 --rule-id 31223 --phase request
+      $ azion describe rules-engine --application-id 1673635839 --rule-id 31223 --phase request
       $ azion describe rules-engine --application-id 1673635839 --rule-id 31223 --phase response --format json
       $ azion describe rules-engine --application-id 1673635839 --rule-id 31223 --phase request --out "./tmp/test.json"
     `),

--- a/pkg/cmd/list/domains/domains.go
+++ b/pkg/cmd/list/domains/domains.go
@@ -20,13 +20,13 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &contracts.ListOptions{}
 	cmd := &cobra.Command{
-		Use:           msg.DomainsListUsage,
-		Short:         msg.DomainsListShortDescription,
-		Long:          msg.DomainsListLongDescription,
+		Use:           msg.Usage,
+		Short:         msg.ShortDescription,
+		Long:          msg.LongDescription,
 		SilenceUsage:  true,
 		SilenceErrors: true, Example: heredoc.Doc(`
-		$ azion list domains
-		$ azion list domains --details
+		$ azion list domain
+		$ azion list domain --details
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := PrintTable(cmd, f, opts); err != nil {
@@ -37,7 +37,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmdutil.AddAzionApiFlags(cmd, opts)
-	cmd.Flags().BoolP("help", "h", false, msg.DomainsListHelpFlag)
+	cmd.Flags().BoolP("help", "h", false, msg.HelpFlag)
 	return cmd
 }
 

--- a/pkg/cmd/list/edge_applications/edge_applications.go
+++ b/pkg/cmd/list/edge_applications/edge_applications.go
@@ -3,8 +3,9 @@ package edge_applications
 import (
 	"context"
 	"fmt"
-	"github.com/aziontech/azion-cli/pkg/logger"
 	"strings"
+
+	"github.com/aziontech/azion-cli/pkg/logger"
 
 	"github.com/fatih/color"
 
@@ -23,9 +24,9 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &contracts.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:           msg.ListUsage,
-		Short:         msg.ListShortDescription,
-		Long:          msg.ListLongDescription,
+		Use:           msg.Usage,
+		Short:         msg.ShortDescription,
+		Long:          msg.LongDescription,
 		SilenceUsage:  true,
 		SilenceErrors: true, Example: heredoc.Doc(`
 		$ azion list edge-application
@@ -50,7 +51,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	flags.Int64Var(&opts.Page, "page", 1, general.ApiListFlagPage)
 	flags.Int64Var(&opts.PageSize, "page_size", 10, general.ApiListFlagPageSize)
 	flags.BoolVar(&opts.Details, "details", false, general.ApiListFlagDetails)
-	flags.BoolP("help", "h", false, msg.ListHelpFlag)
+	flags.BoolP("help", "h", false, msg.HelpFlag)
 	return cmd
 }
 

--- a/pkg/cmd/update/domains/domains.go
+++ b/pkg/cmd/update/domains/domains.go
@@ -36,13 +36,13 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Example: heredoc.Doc(`
-		$ azion update domains --domain-id 1234 --name 'Hello'
-		$ azion update domains --domain-id 1234 --application-id 4321
-		$ azion update domains --domain-id 1234 --cnames www.testhere.com,www.pudim.com
-		$ azion update domains --domain-id 9123 --cname-access-only true
-		$ azion update domains --domain-id 9123 --cname-access-only false
-		$ azion update domains --domain-id 9123 --application-id 192837
-		$ azion update domains --in "update.json"
+		$ azion update domain --domain-id 1234 --name 'Hello'
+		$ azion update domain --domain-id 1234 --application-id 4321
+		$ azion update domain --domain-id 1234 --cnames www.testhere.com,www.pudim.com
+		$ azion update domain --domain-id 9123 --cname-access-only true
+		$ azion update domain --domain-id 9123 --cname-access-only false
+		$ azion update domain --domain-id 9123 --application-id 192837
+		$ azion update domain --in "update.json"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			request := api.UpdateRequest{}

--- a/pkg/cmd/update/edge_application/edge_application.go
+++ b/pkg/cmd/update/edge_application/edge_application.go
@@ -223,7 +223,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 func returnAnyField(cmd *cobra.Command) bool {
 	anyFlagChanged := false
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
-		if flag.Changed && flag.Name != "id" {
+		if flag.Changed && flag.Name != "application-id" {
 			anyFlagChanged = true
 		}
 	})

--- a/pkg/cmd/update/edge_application/edge_application.go
+++ b/pkg/cmd/update/edge_application/edge_application.go
@@ -54,7 +54,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		$ azion update edge-application --in "update.json"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("id") && !cmd.Flags().Changed("in") {
+			if !cmd.Flags().Changed("application-id") && !cmd.Flags().Changed("in") {
 				qs := []*survey.Question{
 					{
 						Name:      "id",
@@ -200,7 +200,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Int64Var(&fields.ID, "id", 0, msg.FlagID)
+	flags.Int64Var(&fields.ID, "application-id", 0, msg.FlagID)
 	flags.StringVar(&fields.Name, "name", "", msg.FlagName)
 	flags.StringVar(&fields.DeliveryProtocol, "delivery-protocol", "", msg.FlagDeliveryProtocol)
 	flags.Int64Var(&fields.HTTPPort, "http-port", 80, msg.FlagHttpPort)

--- a/pkg/cmd/update/edge_application/edge_application_test.go
+++ b/pkg/cmd/update/edge_application/edge_application_test.go
@@ -28,7 +28,7 @@ func TestUpdate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"--id", "1337", "--name", "ATUALIZANDO"})
+		cmd.SetArgs([]string{"--application-id", "1337", "--name", "ATUALIZANDO"})
 
 		err := cmd.Execute()
 
@@ -46,7 +46,7 @@ func TestUpdate(t *testing.T) {
 
 		cmd := NewCmd(f)
 
-		cmd.SetArgs([]string{"--id", "1234", "--active", "unactive"})
+		cmd.SetArgs([]string{"--application-id", "1234", "--active", "unactive"})
 
 		err := cmd.Execute()
 
@@ -83,7 +83,7 @@ func TestUpdate(t *testing.T) {
 		f, _, _ := testutils.NewFactory(mock)
 
 		cmd := NewCmd(f)
-		cmd.SetArgs([]string{"--id", "1337"})
+		cmd.SetArgs([]string{"--application-id", "1337"})
 		err := cmd.Execute()
 		require.ErrorContains(t, err, msg.ErrorNoFieldInformed.Error(), nil)
 	})


### PR DESCRIPTION
**WHAT**
- Fix examples for `create edge-application`;
- Change `domains` to `domain`;