### PR TITLE
refactor: change doc to docs in release builder

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,7 +83,7 @@ changelog:
       regexp: '^.*?sec(\([[:word:]]+\))??!?:.+$'
       order: 40
     - title: 'Documentation Updates'
-      regexp: ^.*?doc(\([[:word:]]+\))??!?:.+$
+      regexp: ^.*?docs(\([[:word:]]+\))??!?:.+$
       order: 50
     - title: Other Work
       order: 999


### PR DESCRIPTION
**WHAT**
Change `doc` to `docs` when creating changelog in release page;