### PR TITLE
chore: flags are shown as global to root command as well

### DIFF
--- a/messages/create/messages.go
+++ b/messages/create/messages.go
@@ -1,7 +1,7 @@
 package create
 
 var (
-	Usage            = "create"
+	Usage            = "create <subcommand> [flags]"
 	ShortDescription = "Creates a new resource on the Azion Edge Platform"
 	LongDescription  = "Creates a new resource on the Azion Edge Platform, requiring any of several sub-commands to create the chosen item"
 	FlagHelp         = "Displays more information about the create command"

--- a/messages/delete/messages.go
+++ b/messages/delete/messages.go
@@ -1,7 +1,7 @@
 package delete
 
 var (
-	Usage            = "delete"
+	Usage            = "delete <subcommand> [flags]"
 	ShortDescription = "Deletes a resource"
 	LongDescription  = "Deletes a resource based on the given ID"
 	FlagHelp         = "Displays more information about the delete command"

--- a/messages/describe/messages.go
+++ b/messages/describe/messages.go
@@ -1,7 +1,7 @@
 package describe
 
 var (
-	Usage            = "describe"
+	Usage            = "describe <subcommand> [flags]"
 	ShortDescription = "Displays information related to a service or resource"
 	LongDescription  = "Displays information related to a service or resource based on a given ID"
 	FlagHelp         = "Displays more information about the describe command"

--- a/messages/list/messages.go
+++ b/messages/list/messages.go
@@ -1,7 +1,7 @@
 package list
 
 var (
-	Usage            = "list [flags]"
+	Usage            = "list <subcommand> [flags]"
 	ShortDescription = "Lists all services or resources you have access to on the platform"
 	LongDescription  = "Lists all services or resources you have access to on the platform available on the Azion platform"
 	FlagHelp         = "Displays more information about the list command"

--- a/messages/update/messages.go
+++ b/messages/update/messages.go
@@ -1,7 +1,7 @@
 package update
 
 var (
-	Usage            = "update [flags]"
+	Usage            = "update <subcommand> [flags]"
 	ShortDescription = "Modifies or changes single or multiple configurations of existing services or resources on Azion"
 	LongDescription  = "Modifies or changes single or multiple configurations of existing services or resources available on the Azion platform"
 	FlagHelp         = "Displays more information about the update command"

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -142,10 +142,17 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 
 	flagUsages := command.LocalFlags().FlagUsages()
 	if flagUsages != "" {
-		helpEntries = append(helpEntries, helpEntry{
-			Title: color.New(styleTitle).Sprint("LOCAL OPTIONS"),
-			Body:  color.New(styleBody).Sprint(dedent(flagUsages)),
-		})
+		if isRootCmd(command) {
+			helpEntries = append(helpEntries, helpEntry{
+				Title: color.New(styleTitle).Sprint("GLOBAL OPTIONS"),
+				Body:  color.New(styleBody).Sprint(dedent(flagUsages)),
+			})
+		} else {
+			helpEntries = append(helpEntries, helpEntry{
+				Title: color.New(styleTitle).Sprint("LOCAL OPTIONS"),
+				Body:  color.New(styleBody).Sprint(dedent(flagUsages)),
+			})
+		}
 	}
 
 	inheritedFlagUsages := command.InheritedFlags().FlagUsages()


### PR DESCRIPTION
**WHAT**
- Add <subcommand> to help messages;
- Change `LOCAL OPTIONS` to `GLOBAL OPTIONS` in root command help;
- Before
```
$ azion -h
Azion CLI 1.2.0
[...]

LOCAL OPTIONS
  -c, --config string      Sets the Azion configuration folder for the current command only, without changing persistent settings.
  -d, --debug              Displays log at a debug level
  -h, --help               Displays more information about the Azion CLI
  -l, --log-level string   Displays log at a debug level (default "info")
  -s, --silent             Silences log completely; mostly used for automation purposes
  -t, --token string       Saves a given personal token locally to authorize CLI commands
  -v, --version            version for azion
  -y, --yes                Answers all yes/no interactions automatically with yes

[...]
```


- After
```
patrick.menoti@FVFFQA7FQ6L4 bin % ./azion -h              
Azion CLI 1.8.0-dev.2-4-ge7e9561

DESCRIPTION
  The Azion Command Line Interface is a unified tool to manage your Azion projects and resources

SYNOPSIS
  azion <command> <subcommand> [flags]

EXAMPLES
  $ azion -h
  

AVAILABLE COMMANDS
  build       Builds an edge application locally
  create      Creates a new resource on the Azion Edge Platform
  delete      Deletes a resource
  deploy      Deploys an edge application onto the Azion platform
  describe    Displays information related to a service or resource
  dev         Starts a local development server for the current application
  help        Help about any command
  init        Initializes an edge application from a starter template
  link        Links a local repo or project folder to an existing application on Azion
  list        Lists all services or resources you have access to on the platform
  update      Modifies or changes single or multiple configurations of existing services or resources on Azion

GLOBAL OPTIONS
  -c, --config string      Sets the Azion configuration folder for the current command only, without changing persistent settings.
  -d, --debug              Displays log at a debug level
  -h, --help               Displays more information about the Azion CLI
  -l, --log-level string   Displays log at a debug level (default "info")
  -s, --silent             Silences log completely; mostly used for automation purposes
  -t, --token string       Saves a given personal token locally to authorize CLI commands
  -v, --version            version for azion
  -y, --yes                Answers all yes/no interactions automatically with yes
  

LEARN MORE
  
  Use 'azion <command> <subcommand> --help' for more information about a command
```