### PR TITLE
feat: add version root command

### DIFF
--- a/messages/version/messages.go
+++ b/messages/version/messages.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	VersionUsage            = "version"
-	VersionShortDescription = "Returns the CLI version"
+	VersionShortDescription = "Outputs Azion CLI installed version"
 	VersionLongDescription  = "Displays the version of the CLI binary installed in the computer."
 	VersionHelpFlag         = "Displays more information about the Azion CLI"
 )

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -102,7 +102,7 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 	cobraCmd.PersistentFlags().BoolVarP(&f.Debug, "debug", "d", false, msg.RootLogDebug)
 	cobraCmd.PersistentFlags().BoolVarP(&f.Silent, "silent", "s", false, msg.RootLogSilent)
 	cobraCmd.PersistentFlags().StringVarP(&f.LogLevel, "log-level", "l", "info", msg.RootLogLevel)
-
+	cobraCmd.PersistentFlags().StringVarP(&f.Version, "version", "v", "", "Outputs Azion CLI installed version")
 	// other flags
 	cobraCmd.Flags().BoolP("help", "h", false, msg.RootHelpFlag)
 

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -14,4 +14,5 @@ type Factory struct {
 	Config     config.Config
 	logger.Logger
 	GlobalFlagAll bool
+	Version       string
 }


### PR DESCRIPTION
What:

Add version root command to override standard cobra description that starts in lower case. 