### PR TITLE
chore: use latest vulcan version

### DIFF
--- a/messages/vulcan/messages.go
+++ b/messages/vulcan/messages.go
@@ -1,0 +1,6 @@
+package vulcan
+
+var (
+	//vulcan version
+	NewMajorVersion = "There is a new version of an azion build tool. Please update your CLI to use these new features"
+)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -23,6 +23,7 @@ type BuildCmd struct {
 	WriteFile             func(filename string, data []byte, perm fs.FileMode) error
 	CommandRunnerStream   func(out io.Writer, cmd string, envvars []string) error
 	CommandRunInteractive func(f *cmdutil.Factory, comm string) error
+	CommandRunner         func(f *cmdutil.Factory, comm string, envVars []string) (string, error)
 	FileReader            func(path string) ([]byte, error)
 	ConfigRelativePath    string
 	GetAzionJsonContent   func() (*contracts.AzionApplicationOptions, error)
@@ -66,6 +67,9 @@ func NewBuildCmd(f *cmdutil.Factory) *BuildCmd {
 		},
 		CommandRunInteractive: func(f *cmdutil.Factory, comm string) error {
 			return utils.CommandRunInteractive(f, comm)
+		},
+		CommandRunner: func(f *cmdutil.Factory, comm string, envVars []string) (string, error) {
+			return utils.CommandRunInteractiveWithOutput(f, comm, envVars)
 		},
 		ConfigRelativePath:    "/azion/config.json",
 		EnvLoader:             utils.LoadEnvVarsFromFile,

--- a/pkg/cmd/build/run.go
+++ b/pkg/cmd/build/run.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (cmd *BuildCmd) run() error {
-	logger.Debug("Running build subcommand from edge_applications command tree")
+	logger.Debug("Running build command")
 
 	err := RunBuildCmdLine(cmd)
 	if err != nil {

--- a/pkg/cmd/build/vulcan.go
+++ b/pkg/cmd/build/vulcan.go
@@ -13,9 +13,20 @@ import (
 )
 
 func vulcan(cmd *BuildCmd, conf *contracts.AzionApplicationOptions) error {
+	// checking if vulcan major is correct
+	vulcanVer, err := cmd.CommandRunner(cmd.f, "npm show edge-functions version", []string{})
+	if err != nil {
+		return err
+	}
+
+	err = vul.CheckVulcanMajor(vulcanVer, cmd.f)
+	if err != nil {
+		return err
+	}
+
 	command := vul.Command("", "build --preset %s --mode %s")
 
-	err := runCommand(cmd, fmt.Sprintf(command, strings.ToLower(conf.Template), strings.ToLower(conf.Mode)))
+	err = runCommand(cmd, fmt.Sprintf(command, strings.ToLower(conf.Template), strings.ToLower(conf.Mode)))
 	if err != nil {
 		return fmt.Errorf(msg.ErrorVulcanExecute.Error(), err.Error())
 	}

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -50,6 +50,7 @@ type InitCmd struct {
 	Mkdir                 func(path string, perm os.FileMode) error
 	GitPlainClone         func(path string, isBare bool, o *git.CloneOptions) (*git.Repository, error)
 	CommandRunner         func(cmd string, envvars []string) (string, int, error)
+	CommandRunnerOutput   func(f *cmdutil.Factory, comm string, envVars []string) (string, error)
 	CommandRunInteractive func(f *cmdutil.Factory, comm string) error
 	ShouldDevDeploy       func(info *InitInfo, msg string) (bool, error)
 	DeployCmd             func(f *cmdutil.Factory) *deploy.DeployCmd
@@ -84,6 +85,9 @@ func NewInitCmd(f *cmdutil.Factory) *InitCmd {
 		},
 		CommandRunInteractive: func(f *cmdutil.Factory, comm string) error {
 			return utils.CommandRunInteractive(f, comm)
+		},
+		CommandRunnerOutput: func(f *cmdutil.Factory, comm string, envVars []string) (string, error) {
+			return utils.CommandRunInteractiveWithOutput(f, comm, envVars)
 		},
 	}
 }

--- a/pkg/cmd/init/utils.go
+++ b/pkg/cmd/init/utils.go
@@ -44,11 +44,23 @@ func askForInput(msg string, defaultIn string) (string, error) {
 }
 
 func (cmd *InitCmd) selectVulcanTemplates(info *InitInfo) error {
+
+	// checking if vulcan major is correct
+	vulcanVer, err := cmd.CommandRunnerOutput(cmd.F, "npm show edge-functions version", []string{})
+	if err != nil {
+		return err
+	}
+
+	err = vul.CheckVulcanMajor(vulcanVer, cmd.F)
+	if err != nil {
+		return err
+	}
+
 	logger.FInfo(cmd.Io.Out, msg.InitGettingVulcan)
 
 	command := vul.Command("", "init --name "+info.Name)
 
-	err := cmd.CommandRunInteractive(cmd.F, command)
+	err = cmd.CommandRunInteractive(cmd.F, command)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/link/utils.go
+++ b/pkg/cmd/link/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	msg "github.com/aziontech/azion-cli/messages/init"
 	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/aziontech/azion-cli/pkg/vulcan"
 	vul "github.com/aziontech/azion-cli/pkg/vulcan"
 	"go.uber.org/zap"
 )
@@ -88,6 +89,17 @@ func askForInput(msg string, defaultIn string) (string, error) {
 func (cmd *LinkCmd) selectVulcanMode(info *LinkInfo) error {
 	if info.Preset == "nextjs" {
 		return nil
+	}
+
+	// checking is vulcan major is correct
+	vulcanVer, err := cmd.CommandRunner(cmd.F, "npm show edge-functions version", []string{})
+	if err != nil {
+		return err
+	}
+
+	err = vulcan.CheckVulcanMajor(vulcanVer, cmd.F)
+	if err != nil {
+		return err
 	}
 
 	logger.FInfo(cmd.Io.Out, msg.InitGettingTemplates)

--- a/pkg/token/models.go
+++ b/pkg/token/models.go
@@ -21,9 +21,10 @@ type Token struct {
 }
 
 type Settings struct {
-	Token           string
-	UUID            string
-	LastUpdateCheck time.Time
+	Token             string
+	UUID              string
+	LastUpdateCheck   time.Time
+	LastVulcanVersion string
 }
 
 type Config struct {

--- a/pkg/vulcan/vulcan.go
+++ b/pkg/vulcan/vulcan.go
@@ -1,12 +1,80 @@
 package vulcan
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	msg "github.com/aziontech/azion-cli/messages/vulcan"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/aziontech/azion-cli/pkg/token"
+	"github.com/pelletier/go-toml"
+	"go.uber.org/zap"
+)
 
 const (
-	versionVulcan        = "2.0.0"
-	installEdgeFunctions = "npx --yes %s edge-functions@%s %s"
+	currentMajor         = 2
+	installEdgeFunctions = "npx --yes %s edge-functions%s %s"
+	firstTimeExecuting   = "@2.1.0"
 )
+
+var versionVulcan = "@latest"
 
 func Command(flags, params string) string {
 	return fmt.Sprintf(installEdgeFunctions, flags, versionVulcan, params)
+}
+
+func CheckVulcanMajor(currentVersion string, f *cmdutil.Factory) error {
+	parts := strings.Split(currentVersion, ".")
+
+	// Extract the first part and convert it to a number
+	if len(parts) > 0 {
+		firstNumber, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return err
+		}
+
+		config, err := token.ReadSettings()
+		if err != nil {
+			return err
+		}
+
+		if firstNumber > currentMajor {
+			logger.FInfo(f.IOStreams.Out, msg.NewMajorVersion)
+
+			if config.LastVulcanVersion == "" {
+				// new version update please
+				versionVulcan = firstTimeExecuting
+				return nil
+			}
+
+			versionVulcan = "@" + strings.TrimRight(config.LastVulcanVersion, "\n")
+			return nil
+		}
+
+		config.LastVulcanVersion = currentVersion
+		client, err := token.New(&token.Config{Client: f.HttpClient})
+		if err != nil {
+			return err
+		}
+
+		byteSettings, err := toml.Marshal(config)
+		if err != nil {
+			logger.Debug("Error while marshalling settings.toml", zap.Error(err))
+			return err
+		}
+
+		_, err = client.Save(byteSettings)
+		if err != nil {
+			logger.Debug("Error while saving settings", zap.Error(err))
+			return err
+		}
+
+	} else {
+		logger.Debug("Failed to parse information on current vulcan version")
+		versionVulcan = firstTimeExecuting
+		return nil
+	}
+	return nil
 }

--- a/pkg/vulcan/vulcan_test.go
+++ b/pkg/vulcan/vulcan_test.go
@@ -17,7 +17,7 @@ func TestCommand(t *testing.T) {
 			args: args{
 				params: "presets ls",
 			},
-			want: "npx --yes  edge-functions@2.0.0 presets ls",
+			want: "npx --yes  edge-functions@latest presets ls",
 		},
 		{
 			name: "with flags",
@@ -25,14 +25,14 @@ func TestCommand(t *testing.T) {
 				flags:  "--loglevel=error --no-update-notifier",
 				params: "presets ls",
 			},
-			want: "npx --yes --loglevel=error --no-update-notifier edge-functions@2.0.0 presets ls",
+			want: "npx --yes --loglevel=error --no-update-notifier edge-functions@latest presets ls",
 		},
 		{
 			name: "no params",
 			args: args{
 				flags: "--loglevel=error --no-update-notifier",
 			},
-			want: "npx --yes --loglevel=error --no-update-notifier edge-functions@2.0.0 ",
+			want: "npx --yes --loglevel=error --no-update-notifier edge-functions@latest ",
 		},
 	}
 	for _, tt := range tests {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/manifoldco/promptui"
 
@@ -552,4 +554,20 @@ func Concat(strs ...string) string {
 		sb.WriteString(strs[i])
 	}
 	return sb.String()
+}
+
+func Format(input string) (int, error) {
+	numberString := ""
+	for _, char := range input {
+		if unicode.IsDigit(char) {
+			numberString += string(char)
+		}
+	}
+
+	number, err := strconv.Atoi(numberString)
+	if err != nil {
+		return 0, err
+	}
+
+	return number, nil
 }


### PR DESCRIPTION
**WHAT**
- Use latest version of vulcan as default, except:
  - There is a new major version of Vulcan: in this case, we warn the user to update their CLI to use the new Vulcan version;
  - First time using: we suggest a default version;