### PR TITLE
fix: handler reading param twice #patch

### DIFF
--- a/pkg/cmd/login/browser.go
+++ b/pkg/cmd/login/browser.go
@@ -23,7 +23,9 @@ func browserLogin(f *cmdutil.Factory) error {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		paramValue := r.URL.Query().Get("c")
 		_, _ = io.WriteString(w, msg.BrowserMsg)
-		tokenValue = paramValue
+		if paramValue != "" {
+			tokenValue = paramValue
+		}
 		cancel()
 	})
 


### PR DESCRIPTION
**WHAT**
- Fix problem where param would be read twice, and save an empty token;