### PR TITLE
fix: saving preset and mode incorrectly

### DIFF
--- a/pkg/cmd/link/template.go
+++ b/pkg/cmd/link/template.go
@@ -2,6 +2,7 @@ package link
 
 import (
 	"encoding/json"
+	"strings"
 
 	msg "github.com/aziontech/azion-cli/messages/init"
 	"github.com/aziontech/azion-cli/pkg/contracts"
@@ -18,8 +19,8 @@ func (cmd *LinkCmd) createTemplateAzion(info *LinkInfo) error {
 	azionJson := &contracts.AzionApplicationOptions{
 		Name:        info.Name,
 		Env:         "production",
-		Template:    info.Preset,
-		Mode:        info.Mode,
+		Template:    strings.ToLower(info.Preset),
+		Mode:        strings.ToLower(info.Mode),
 		Prefix:      "",
 		ProjectRoot: info.PathWorkingDir,
 	}


### PR DESCRIPTION
**WHAT**
- Preset and Mode were being saved incorrectly in azion.json file, thus causing errors when these fields were being verified by other commands;