### PR TITLE
fix: add missing fields in origin create/update

### DIFF
--- a/messages/origin/messages.go
+++ b/messages/origin/messages.go
@@ -41,9 +41,12 @@ var (
 	// [ ask ]
 	AskAppID      = "Enter the ID of the Edge Application this Origin is linked to:"
 	AskName       = "Enter the new Origin's Name:"
+	AskBucket     = "Enter the new Origin's Bucket:"
+	AskPrefix     = "Enter the new Origin's Prefix, or leave it blank if you are not using any prefix:"
 	AskAddresses  = "Enter the new Origin's Addresses:"
 	AskHostHeader = "Enter the new Origin's Host Header:"
 	AskOriginKey  = "Enter the Origin's Key:"
+	AskOriginType = "Enter the Origin's type:"
 
 	// [ flags ]
 	FlagEdgeApplicationID    = "Unique identifier for an Edge Application"
@@ -57,6 +60,10 @@ var (
 	FlagHmacAuthentication   = "Whether Hmac Authentication is used or not"
 	FlagHmacRegionName       = "Informs Hmac region name"
 	FlagHmacAccessKey        = "Informs Hmac Access Key"
+	FlagBucket               = "The Origin's bucket. Required flag that must be informed when origin-type is object_storage"
+	FlagBucketUpdate         = "The Origin's bucket"
+	FlagPrefix               = "The Origin's prefix. Optional flag that can be informed when origin-type is object_storage"
+	FlagPrefixUpdate         = "The Origin's prefix"
 	FlagHmacSecretKey        = "Informs Hmac Secret Key"
 	FlagFile                 = "Path to a JSON file containing the attributes of the Origin that will be created; you can use - for reading from stdin"
 	OriginsFileWritten       = "File successfully written to: %s\n"

--- a/pkg/cmd/create/origin/origin_test.go
+++ b/pkg/cmd/create/origin/origin_test.go
@@ -29,6 +29,7 @@ func TestCreate(t *testing.T) {
 			"--name", "onepieceisthebest",
 			"--addresses", "asdfsd.cvdf",
 			"--host-header", "asdfsdfsd.cvdf",
+			"--origin-type", "single_origin",
 		})
 
 		err := cmd.Execute()

--- a/pkg/cmd/update/origin/origin.go
+++ b/pkg/cmd/update/origin/origin.go
@@ -33,6 +33,8 @@ type Fields struct {
 	HmacAccessKey        string
 	HmacSecretKey        string
 	Path                 string
+	Bucket               string
+	Prefix               string
 }
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
@@ -133,6 +135,12 @@ func createRequestFromFlags(cmd *cobra.Command, fields *Fields, request *api.Upd
 	if cmd.Flags().Changed("origin-path") {
 		request.SetOriginPath(fields.OriginPath)
 	}
+	if cmd.Flags().Changed("bucket") {
+		request.SetBucket(fields.Bucket)
+	}
+	if cmd.Flags().Changed("prefix") {
+		request.SetPrefix(fields.Prefix)
+	}
 
 	if cmd.Flags().Changed("hmac-authentication") {
 		hmacAuth, err := strconv.ParseBool(fields.HmacAuthentication)
@@ -170,6 +178,8 @@ func addFlags(flags *pflag.FlagSet, fields *Fields) {
 	flags.StringVar(&fields.HmacRegionName, "hmac-region-name", "", msg.FlagHmacRegionName)
 	flags.StringVar(&fields.HmacAccessKey, "hmac-access-key", "", msg.FlagHmacAccessKey)
 	flags.StringVar(&fields.HmacSecretKey, "hmac-secret-key", "", msg.FlagHmacSecretKey)
+	flags.StringVar(&fields.Bucket, "bucket", "", msg.FlagBucketUpdate)
+	flags.StringVar(&fields.Prefix, "prefix", "", msg.FlagPrefixUpdate)
 	flags.StringVar(&fields.Path, "file", "", msg.FlagFile)
 	flags.BoolP("help", "h", false, msg.UpdateFlagHelp)
 }

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -336,7 +336,12 @@ func checkStatusCode400Error(httpResp *http.Response) error {
 		return err
 	}
 
-	return fmt.Errorf("%s", string(responseBody))
+	result := strings.ReplaceAll(string(responseBody), "{", "")
+	result = strings.ReplaceAll(result, "}", "")
+	result = strings.ReplaceAll(result, "[", "")
+	result = strings.ReplaceAll(result, "]", "")
+
+	return fmt.Errorf("%s", result)
 }
 
 func checkNoProduct(body string) error {


### PR DESCRIPTION
**WHAT**
- Add missing fields to origin create and update:
   - Creating object storage origin was impossible before this change.