### PR TITLE
feat: add metrics collector to all commands

### DIFF
--- a/messages/root/messages.go
+++ b/messages/root/messages.go
@@ -15,13 +15,14 @@ var (
 	TokenUsedIn     = "This token will be used by default with all commands"
 
 	// update messages
-	NewVersion      = "There is a new version of Azion CLI available\n"
-	BrewUpdate      = "Please run: 'brew upgrade azion' to update to the latest version\n"
-	ReleasePage     = "Please visit our Releases page and download the appropriate file\n"
-	CouldNotGetUser = "Sadly, we could not get information on your system to indicate the correct update form\n"
-	DownloadRelease = "Visit https://github.com/aziontech/azion/releases to download the correct package"
-	RpmUpdate       = "Please run: 'sudo rpm -i <downloaded_file>' to update to the latest version\n"
-	DpkgUpdate      = "Please run: 'sudo dpkg -i <downloaded_file>' to update to the latest version\n"
-	ApkUpdate       = "Please run: 'sudo apk add <downloaded_file>' to update to the latest version\n"
-	UnsupportedOS   = "Unsupported Operating System\n"
+	NewVersion        = "There is a new version of Azion CLI available\n"
+	BrewUpdate        = "Please run: 'brew upgrade azion' to update to the latest version\n"
+	ReleasePage       = "Please visit our Releases page and download the appropriate file\n"
+	CouldNotGetUser   = "Sadly, we could not get information on your system to indicate the correct update form\n"
+	DownloadRelease   = "Visit https://github.com/aziontech/azion/releases to download the correct package"
+	RpmUpdate         = "Please run: 'sudo rpm -i <downloaded_file>' to update to the latest version\n"
+	DpkgUpdate        = "Please run: 'sudo dpkg -i <downloaded_file>' to update to the latest version\n"
+	ApkUpdate         = "Please run: 'sudo apk add <downloaded_file>' to update to the latest version\n"
+	AskCollectMetrics = "To better understand user needs and enhance our application, we gather anonymous data. Do you agree to participate? (Y/n)"
+	UnsupportedOS     = "Unsupported Operating System\n"
 )

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -52,7 +52,7 @@ type InitCmd struct {
 	CommandRunner         func(cmd string, envvars []string) (string, int, error)
 	CommandRunnerOutput   func(f *cmdutil.Factory, comm string, envVars []string) (string, error)
 	CommandRunInteractive func(f *cmdutil.Factory, comm string) error
-	ShouldDevDeploy       func(info *InitInfo, msg string) bool
+	ShouldDevDeploy       func(info *InitInfo, msg string, defaultYes bool) bool
 	DeployCmd             func(f *cmdutil.Factory) *deploy.DeployCmd
 	DevCmd                func(f *cmdutil.Factory) *dev.DevCmd
 	ChangeDir             func(dir string) error
@@ -164,10 +164,10 @@ func (cmd *InitCmd) Run(info *InitInfo) error {
 		return msg.ErrorWorkingDir
 	}
 
-	shouldDev := cmd.ShouldDevDeploy(info, "Do you want to start a local development server?")
+	shouldDev := cmd.ShouldDevDeploy(info, "Do you want to start a local development server? (y/N)", false)
 
 	if shouldDev {
-		shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to start local development server")
+		shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to start local development server (y/N)", false)
 
 		if shouldDeps {
 			answer, err := utils.GetPackageManager()
@@ -192,10 +192,10 @@ func (cmd *InitCmd) Run(info *InitInfo) error {
 		logger.FInfo(cmd.Io.Out, msg.InitDevCommand)
 	}
 
-	shouldDeploy := cmd.ShouldDevDeploy(info, "Do you want to deploy your project?")
+	shouldDeploy := cmd.ShouldDevDeploy(info, "Do you want to deploy your project? (y/N)", false)
 	if shouldDeploy {
 
-		shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to deploy your project")
+		shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to deploy your project (y/N)", false)
 		if err != err {
 			return err
 		}

--- a/pkg/cmd/init/utils.go
+++ b/pkg/cmd/init/utils.go
@@ -14,11 +14,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func shouldDevDeploy(info *InitInfo, msg string) bool {
+func shouldDevDeploy(info *InitInfo, msg string, defaultYes bool) bool {
 	if info.GlobalFlagAll {
 		return true
 	}
-	return helpers.Confirm(msg)
+	return helpers.Confirm(msg, defaultYes)
 }
 
 func askForInput(msg string, defaultIn string) (string, error) {

--- a/pkg/cmd/link/link.go
+++ b/pkg/cmd/link/link.go
@@ -49,7 +49,7 @@ type LinkCmd struct {
 	CommandRunner         func(f *cmdutil.Factory, comm string, envVars []string) (string, error)
 	CommandRunInteractive func(f *cmdutil.Factory, comm string) error
 	ShouldConfigure       func(info *LinkInfo) bool
-	ShouldDevDeploy       func(info *LinkInfo, msg string) bool
+	ShouldDevDeploy       func(info *LinkInfo, msg string, defaultYes bool) bool
 	DeployCmd             func(f *cmdutil.Factory) *deploy.DeployCmd
 	DevCmd                func(f *cmdutil.Factory) *dev.DevCmd
 	F                     *cmdutil.Factory
@@ -177,10 +177,10 @@ func (cmd *LinkCmd) run(info *LinkInfo, options *contracts.AzionApplicationOptio
 		logger.FInfo(cmd.Io.Out, msg.WebAppLinkCmdSuccess)
 
 		if !info.Auto {
-			shouldDev := cmd.ShouldDevDeploy(info, "Do you want to start a local development server?")
+			shouldDev := cmd.ShouldDevDeploy(info, "Do you want to start a local development server? (y/N)", false)
 
 			if shouldDev {
-				shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to start local development server")
+				shouldDeps := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to start local development server (y/N)", false)
 
 				if shouldDeps {
 					answer, err := utils.GetPackageManager()
@@ -205,10 +205,10 @@ func (cmd *LinkCmd) run(info *LinkInfo, options *contracts.AzionApplicationOptio
 				logger.FInfo(cmd.Io.Out, msg.LinkDevCommand)
 			}
 
-			shouldDeploy := cmd.ShouldDevDeploy(info, "Do you want to deploy your project?")
+			shouldDeploy := cmd.ShouldDevDeploy(info, "Do you want to deploy your project? (y/N)", false)
 
 			if shouldDeploy {
-				shouldYarn := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to deploy the project")
+				shouldYarn := cmd.ShouldDevDeploy(info, "Do you want to install project dependencies? This may be required to deploy the project (y/N)", false)
 
 				if shouldYarn {
 					answer, err := utils.GetPackageManager()

--- a/pkg/cmd/link/utils.go
+++ b/pkg/cmd/link/utils.go
@@ -17,15 +17,15 @@ func shouldConfigure(info *LinkInfo) bool {
 	if info.GlobalFlagAll || info.Auto {
 		return true
 	}
-	msg := fmt.Sprintf("Do you want to link %s to Azion?", info.PathWorkingDir)
-	return helpers.Confirm(msg)
+	msg := fmt.Sprintf("Do you want to link %s to Azion? (y/N)", info.PathWorkingDir)
+	return helpers.Confirm(msg, false)
 }
 
-func shouldDevDeploy(info *LinkInfo, msg string) bool {
+func shouldDevDeploy(info *LinkInfo, msg string, defaultYes bool) bool {
 	if info.GlobalFlagAll {
 		return true
 	}
-	return helpers.Confirm(msg)
+	return helpers.Confirm(msg, defaultYes)
 }
 
 func shouldFetch(cmd *LinkCmd, info *LinkInfo) (bool, error) {
@@ -35,7 +35,7 @@ func shouldFetch(cmd *LinkCmd, info *LinkInfo) (bool, error) {
 		if info.GlobalFlagAll || info.Auto {
 			shouldFetchTemplates = true
 		} else {
-			return helpers.Confirm("This project was already configured. Do you want to override the previous configuration?"), nil
+			return helpers.Confirm("This project was already configured. Do you want to override the previous configuration? (y/N)", false), nil
 		}
 
 		if shouldFetchTemplates {

--- a/pkg/cmd/root/post_command.go
+++ b/pkg/cmd/root/post_command.go
@@ -62,9 +62,15 @@ func saveMetrict(cmd *cobra.Command) error {
 	data[total]++
 
 	// Reset file offset to the beginning
-	file.Seek(0, 0)
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return err
+	}
 	// Truncate the file in case the new content is smaller than the previous one
-	file.Truncate(0)
+	err = file.Truncate(0)
+	if err != nil {
+		return err
+	}
 
 	// Encode and write the updated map back to the file
 	if err := json.NewEncoder(file).Encode(data); err != nil {

--- a/pkg/cmd/root/post_command.go
+++ b/pkg/cmd/root/post_command.go
@@ -1,0 +1,75 @@
+package root
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aziontech/azion-cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+const (
+	metricsFilename = "metrics.json"
+	total           = "total-commands-executed"
+)
+
+func saveMetrict(cmd *cobra.Command) error {
+	//1 = authorize; anything different than 1 means that the user did not authorize metrics collection, or did not answer the question yet
+	if globalSettings.AuthorizeMetricsCollection != 1 {
+		return nil
+	}
+	dir, err := config.Dir()
+	if err != nil {
+		return err
+	}
+
+	ignoredWords := map[string]bool{
+		"__complete": true,
+	}
+	if ignoredWords[cmd.Parent().Name()] || ignoredWords[cmd.Name()] {
+		return nil
+	}
+
+	metricsLocation := filepath.Join(dir, metricsFilename)
+
+	file, err := os.OpenFile(metricsLocation, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var data map[string]int
+
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&data)
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	// If EOF is encountered or the file is empty, initialize data as an empty map
+	if data == nil {
+		data = make(map[string]int)
+	}
+
+	commandRun := cmd.Parent().Name() + "-" + cmd.Name()
+	rewrittenCommand := strings.TrimPrefix(commandRun, "azion-")
+
+	data[rewrittenCommand]++
+	data[total]++
+
+	// Reset file offset to the beginning
+	file.Seek(0, 0)
+	// Truncate the file in case the new content is smaller than the previous one
+	file.Truncate(0)
+
+	// Encode and write the updated map back to the file
+	if err := json.NewEncoder(file).Encode(data); err != nil {
+		log.Fatal(err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -51,6 +51,8 @@ var (
 	configFlag string
 )
 
+var globalSettings *token.Settings
+
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewRootCmd(f), f)
 }
@@ -69,6 +71,13 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 			})
 			if err != nil {
 				return err
+			}
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			err := saveMetrict(cmd)
+			if err != nil {
+				logger.Debug("Error while saving metrics", zap.Error(err))
 			}
 			return nil
 		},

--- a/pkg/token/models.go
+++ b/pkg/token/models.go
@@ -21,10 +21,11 @@ type Token struct {
 }
 
 type Settings struct {
-	Token             string
-	UUID              string
-	LastUpdateCheck   time.Time
-	LastVulcanVersion string
+	Token                      string
+	UUID                       string
+	LastCheck                  time.Time
+	LastVulcanVersion          string
+	AuthorizeMetricsCollection int
 }
 
 type Config struct {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -584,14 +584,16 @@ func Concat(strs ...string) string {
 	return sb.String()
 }
 
-func Confirm(msg string) bool {
-	fmt.Printf("🤔 \x1b[32m%s (y/N) \x1b[0m", msg)
+func Confirm(msg string, defaultYes bool) bool {
+	fmt.Printf("🤔 \x1b[32m%s \x1b[0m", msg)
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	confirm := scanner.Text()
 
-	if confirm == "" {
+	if confirm == "" && !defaultYes {
 		return false
+	} else if confirm == "" && defaultYes {
+		return true
 	}
 
 	switch confirm {
@@ -600,8 +602,8 @@ func Confirm(msg string) bool {
 	case "n", "N":
 		return false
 	default:
-		fmt.Printf("\x1b[33m%s\x1b[0m", "⚠️ Invalid input. Please enter 'y' or 'n'.")
-		return Confirm(msg)
+		fmt.Printf("\x1b[33m%s\x1b[0m", "⚠️ Invalid input. Please enter 'y' or 'n'.\n")
+		return Confirm(msg, defaultYes)
 	}
 }
 


### PR DESCRIPTION
**WHAT**
- ask user if they allow metrics to be collected (default: yes). 
  - saving the answer in the settings.toml file, using the following pattern: (0 = not answered yet; 1 = authorized; 2 = not authorized);
- PersistentPostRunE added: 
  - runs after every command is completed and updates the following metrics (if the user allowed):
    - `total-commands-executed` (count of every command executed by the user);
    - `command-subcommand` , for e.g.: `list-domain` (count of executions per command);

Metrics are being saved in a map of ints. In the future, when more complex metrics are added, we might need to update this variable to a map of interfaces perhaps;