### PR TITLE
fix: input without respect 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -57,6 +58,8 @@ var (
 	startTime      time.Time
 )
 
+const PREFIX_FLAG = "--"
+
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewRootCmd(f), f)
 }
@@ -70,10 +73,16 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
 			logger.LogLevel(f.Logger)
+
+			if strings.HasPrefix(configFlag, PREFIX_FLAG) {
+				return fmt.Errorf("A configuration path is expected for your location, not a flag")
+			}
+
 			err := doPreCommandCheck(cmd, f, PreCmd{
 				config: configFlag,
 				token:  tokenFlag,
 			})
+
 			if err != nil {
 				return err
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 )
 
-const defaultPath = ".azion"
+const DEFAULT_PATH = ".azion"
 
-var pathDir string = defaultPath
+var pathDir string = DEFAULT_PATH 
 
 type Config interface {
 	GetString(key string) string
@@ -17,13 +17,17 @@ func SetPath(cp string) {
 	pathDir = cp
 }
 
+func GetPath() string {
+	return pathDir
+}
+
 func Dir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	if pathDir != defaultPath {
+	if pathDir != DEFAULT_PATH {
 		home = ""
 	}
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -154,7 +154,7 @@ func ReadSettings() (Settings, error) {
 
 		// File does not exist, create it with default settings
 		if config.GetPath() == config.DEFAULT_PATH || 
-			utils.Confirm(false, "do you want to create new settings on the path you entered? (Y/n)", true) {
+			utils.Confirm(false, "Do you want to create new settings on the path you entered? (Y/n)", true) {
 			defaultSettings := Settings{}
 			err := WriteSettings(defaultSettings)
 			if err != nil {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -150,16 +150,21 @@ func ReadSettings() (Settings, error) {
 	filePath := filepath.Join(dir, settingsFilename)
 
 	// Check if the file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) { 	
+
 		// File does not exist, create it with default settings
-		defaultSettings := Settings{}
+		if config.GetPath() == config.DEFAULT_PATH || 
+			utils.Confirm(false, "do you want to create new settings on the path you entered? (Y/n)", true) {
+			defaultSettings := Settings{}
+			err := WriteSettings(defaultSettings)
+			if err != nil {
+				return Settings{}, fmt.Errorf("failed to create settings file: %w", err)
+			}
 
-		err := WriteSettings(defaultSettings)
-		if err != nil {
-			return Settings{}, fmt.Errorf("failed to create settings file: %w", err)
-		}
+			return defaultSettings, nil
+		}		
 
-		return defaultSettings, nil
+		return Settings{}, fmt.Errorf("Provide the correct path of the configuration file. Make sure the file is in .toml format.")
 	}
 
 	// Read the file
@@ -177,4 +182,3 @@ func ReadSettings() (Settings, error) {
 	return settings, nil
 }
 
-// func GetUserInfo


### PR DESCRIPTION
#### Description:
The problem is related to the question of authorization to metrics that the idea is to be asked only once, only every time you set a new configuration this question needs to be answered for the new configuration we do not make the copy for the user to have the freedom to choose if in this new configuration. The real problem was that we confused the use of the flag that receives parameters even with the flag prefix and for this reason it is asked again.

- fix: checks a value with a flag smell. chaves: 'parece de tamarindo é de limão, com sabor de groselha
