### PR TITLE
fix: after the first deploy, we should not update rules engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/cmd/deploy/manifest.go
+++ b/pkg/cmd/deploy/manifest.go
@@ -87,6 +87,10 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 	var cacheID int64 = 0
 
 	for _, route := range manifest.Routes {
+		if conf.RulesEngine.Created {
+			break
+		}
+
 		if route.From == "/_next/data/" {
 			continue
 		}
@@ -96,7 +100,7 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 			err := cmd.doFunction(clients, ctx, conf)
 			if err != nil {
 				return err
-			}	
+			}
 
 			var reqCache apiEdgeApplications.CreateCacheSettingsRequest
 			reqCache.SetName("function policy")
@@ -113,7 +117,7 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 				return err
 			}
 			cacheID = cache.GetId()
-			logger.FInfo(cmd.F.IOStreams.Out, msg.CacheSettingsSuccessful)	
+			logger.FInfo(cmd.F.IOStreams.Out, msg.CacheSettingsSuccessful)
 		}
 
 		err = cmd.doOrigin(clients.EdgeApplication, clients.Origin, ctx, conf)


### PR DESCRIPTION
**WHAT**
- If it's not the first run, skip updating rules engine/cache settings;