### PR TITLE
fix: update --config flag behavior and respect metrics acceptance input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/messages/root/errors.go
+++ b/messages/root/errors.go
@@ -3,7 +3,8 @@ package root
 import "errors"
 
 var (
-	ErrorCurrentUser       = errors.New("Failed to get current user's information.")
-	ErrorMarshalUserInfo   = errors.New("Failed to marshal current user information.")
-	ErrorUnmarshalUserInfo = errors.New("Failed to unmarshal current user information.")
+	ErrorCurrentUser          = errors.New("Failed to get current user's information.")
+	ErrorMarshalUserInfo      = errors.New("Failed to marshal current user information.")
+	ErrorUnmarshalUserInfo    = errors.New("Failed to unmarshal current user information.")
+	ErrorReadFileSettingsToml = errors.New("Provide the correct path of the configuration file. Make sure the file is in .toml format, access the document for more information https://www.azion.com/en/documentation/devtools/cli/globals/#config")
 )

--- a/pkg/cmd/root/pre_command.go
+++ b/pkg/cmd/root/pre_command.go
@@ -40,8 +40,10 @@ func doPreCommandCheck(cmd *cobra.Command, f *cmdutil.Factory, pre PreCmd) error
 	rewrittenCommand := strings.ReplaceAll(strings.TrimPrefix(commandName, "azion "), " ", "-")
 	commandName = rewrittenCommand
 
-	if err := setConfigPath(cmd, pre.config); err != nil {
-		return err
+	if cmd.Flags().Changed("config") {
+		if err := config.SetPath(pre.config); err != nil {
+			return err
+		}
 	}
 
 	settings, err := token.ReadSettings()
@@ -61,16 +63,6 @@ func doPreCommandCheck(cmd *cobra.Command, f *cmdutil.Factory, pre PreCmd) error
 	//both verifications occurs if 24 hours have passed since the last execution
 	if err := checkForUpdateAndMetrics(version.BinVersion, f, globalSettings); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func setConfigPath(cmd *cobra.Command, cfg string) error {
-
-	if cmd.Flags().Changed("config") {
-		config.SetPath(cfg)
-		return nil
 	}
 
 	return nil

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -78,28 +78,10 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("A configuration path is expected for your location, not a flag")
 			}
 
-			err := doPreCommandCheck(cmd, f, PreCmd{
+			return doPreCommandCheck(cmd, f, PreCmd{
 				config: configFlag,
 				token:  tokenFlag,
 			})
-
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			executionTime := time.Since(startTime).Seconds()
-
-			//1 = authorize; anything different than 1 means that the user did not authorize metrics collection, or did not answer the question yet
-			if globalSettings.AuthorizeMetricsCollection != 1 {
-				return nil
-			}
-			err := metric.TotalCommandsCount(cmd, commandName, executionTime, true)
-			if err != nil {
-				logger.Debug("Error while saving metrics", zap.Error(err))
-			}
-			return nil
 		},
 		Example: heredoc.Doc(`
 		$ azion
@@ -193,15 +175,11 @@ func Execute() {
 	}
 
 	cmd := NewCmd(factory)
-
 	err := cmd.Execute()
-	if err != nil {
-		executionTime := time.Since(startTime).Seconds()
-		err := metric.TotalCommandsCount(cmd, commandName, executionTime, false)
-		if err != nil {
-			cobra.CheckErr(err)
-		}
+	executionTime := time.Since(startTime).Seconds()
+	errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
+	if errMetrics != nil {
+		logger.Debug("Error while saving metrics", zap.Error(err))
 	}
-
 	cobra.CheckErr(err)
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -57,6 +58,8 @@ var (
 	startTime      time.Time
 )
 
+const PREFIX_FLAG = "--"
+
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewRootCmd(f), f)
 }
@@ -70,10 +73,16 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
 			logger.LogLevel(f.Logger)
+
+			if strings.HasPrefix(configFlag, PREFIX_FLAG) {
+				return fmt.Errorf("A configuration path is expected for your location, not a flag")
+			}
+
 			err := doPreCommandCheck(cmd, f, PreCmd{
 				config: configFlag,
 				token:  tokenFlag,
 			})
+
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -179,7 +179,7 @@ func Execute() {
 	executionTime := time.Since(startTime).Seconds()
 
 	// 1 = authorize; anything different than 1 means that the user did not authorize metrics collection, or did not answer the question yet
-	if globalSettings.AuthorizeMetricsCollection == 1 {
+	if globalSettings != nil || globalSettings.AuthorizeMetricsCollection == 1 {
 		errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
 		if errMetrics != nil {
 			logger.Debug("Error while saving metrics", zap.Error(err))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -179,10 +179,12 @@ func Execute() {
 	executionTime := time.Since(startTime).Seconds()
 
 	// 1 = authorize; anything different than 1 means that the user did not authorize metrics collection, or did not answer the question yet
-	if globalSettings != nil || globalSettings.AuthorizeMetricsCollection == 1 {
-		errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
-		if errMetrics != nil {
-			logger.Debug("Error while saving metrics", zap.Error(err))
+	if globalSettings != nil {
+		if  globalSettings.AuthorizeMetricsCollection == 1 {
+			errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
+			if errMetrics != nil {
+				logger.Debug("Error while saving metrics", zap.Error(err))
+			}
 		}
 	}
 	cobra.CheckErr(err)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -177,9 +177,13 @@ func Execute() {
 	cmd := NewCmd(factory)
 	err := cmd.Execute()
 	executionTime := time.Since(startTime).Seconds()
-	errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
-	if errMetrics != nil {
-		logger.Debug("Error while saving metrics", zap.Error(err))
+
+	// 1 = authorize; anything different than 1 means that the user did not authorize metrics collection, or did not answer the question yet
+	if globalSettings.AuthorizeMetricsCollection == 1 {
+		errMetrics := metric.TotalCommandsCount(cmd, commandName, executionTime, err)
+		if errMetrics != nil {
+			logger.Debug("Error while saving metrics", zap.Error(err))
+		}
 	}
 	cobra.CheckErr(err)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 )
 
-const defaultPath = ".azion"
+const DEFAULT_PATH = ".azion"
 
-var pathDir string = defaultPath
+var pathDir string = DEFAULT_PATH 
 
 type Config interface {
 	GetString(key string) string
@@ -17,13 +17,17 @@ func SetPath(cp string) {
 	pathDir = cp
 }
 
+func GetPath() string {
+	return pathDir
+}
+
 func Dir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	if pathDir != defaultPath {
+	if pathDir != DEFAULT_PATH {
 		home = ""
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,33 +3,60 @@ package config
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/aziontech/azion-cli/messages/root"
 )
 
-const DEFAULT_PATH = ".azion"
+const (
+	DEFAULT_DIR      = ".azion"
+	DEFAULT_SETTINGS = "settings.toml"
+	DEFAULT_METRICS  = "metrics.json"
+)
 
-var pathDir string = DEFAULT_PATH 
+var (
+	pathDir      string = DEFAULT_DIR
+	pathSettings string = DEFAULT_SETTINGS
+)
 
 type Config interface {
 	GetString(key string) string
 }
 
-func SetPath(cp string) {
-	pathDir = cp
+func SetPath(path string) error {
+	if filepath.Ext(path) != ".toml" {
+		return root.ErrorReadFileSettingsToml
+	}
+
+	pathDir = filepath.Dir(path)
+	pathSettings = filepath.Base(path)
+
+	return nil
 }
 
 func GetPath() string {
 	return pathDir
 }
 
-func Dir() (string, error) {
+type DirPath struct {
+	Dir      string
+	Settings string
+	Metrics  string
+}
+
+func Dir() (DirPath, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return DirPath{}, err
 	}
 
-	if pathDir != DEFAULT_PATH {
+	if pathDir != DEFAULT_DIR {
 		home = ""
 	}
 
-	return filepath.Join(home, pathDir), nil
+	dirPath := DirPath{
+		Dir:      filepath.Join(home, pathDir),
+		Settings: pathSettings,
+		Metrics:  DEFAULT_METRICS,
+	}
+	return dirPath, nil
 }

--- a/pkg/metric/count.go
+++ b/pkg/metric/count.go
@@ -15,10 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	metricsFilename = "metrics.json"
-)
-
 type command struct {
 	TotalSuccess  int
 	TotalFailed   int
@@ -28,9 +24,14 @@ type command struct {
 	Shell         string
 }
 
-func TotalCommandsCount(cmd *cobra.Command, commandName string, executionTime float64, success bool) error {
+func TotalCommandsCount(cmd *cobra.Command, commandName string, executionTime float64, errExec error) error {
 	if commandName == "" {
 		return nil
+	}
+
+	success := true
+	if errExec != nil {
+		success = false
 	}
 
 	dir, err := config.Dir()
@@ -47,7 +48,7 @@ func TotalCommandsCount(cmd *cobra.Command, commandName string, executionTime fl
 		return nil
 	}
 
-	metricsLocation := filepath.Join(dir, metricsFilename)
+	metricsLocation := filepath.Join(dir.Dir, dir.Metrics)
 
 	file, err := os.OpenFile(metricsLocation, os.O_RDWR|os.O_CREATE, 0777)
 	if err != nil {
@@ -88,7 +89,7 @@ func TotalCommandsCount(cmd *cobra.Command, commandName string, executionTime fl
 		data[commandName].VulcanVersion = tagName[1:]
 	}
 
-  data[commandName].Shell = shell
+	data[commandName].Shell = shell
 	if success {
 		data[commandName].TotalSuccess++
 	} else {

--- a/pkg/metric/count.go
+++ b/pkg/metric/count.go
@@ -44,7 +44,7 @@ func TotalCommandsCount(cmd *cobra.Command, commandName string, executionTime fl
 		"completion": true,
 	}
 
-	if ignoredWords[cmd.Name()] {
+	if ignoredWords[commandName] {
 		return nil
 	}
 

--- a/pkg/metric/segment.go
+++ b/pkg/metric/segment.go
@@ -23,7 +23,7 @@ func location() string {
 		logger.Debug("Failed get path file metric.json", zap.Error(err))
 	}
 	const metricsFilename = "metrics.json"
-	return filepath.Join(dir, metricsFilename)
+	return filepath.Join(dir.Dir, dir.Metrics)
 }
 
 func readLocalMetrics() map[string]command {

--- a/pkg/metric/segment.go
+++ b/pkg/metric/segment.go
@@ -22,7 +22,6 @@ func location() string {
 	if err != nil {
 		logger.Debug("Failed get path file metric.json", zap.Error(err))
 	}
-	const metricsFilename = "metrics.json"
 	return filepath.Join(dir.Dir, dir.Metrics)
 }
 

--- a/pkg/token/models.go
+++ b/pkg/token/models.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-const settingsFilename = "settings.toml"
-
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -154,7 +154,7 @@ func ReadSettings() (Settings, error) {
 
 		// File does not exist, create it with default settings
 		if config.GetPath() == config.DEFAULT_PATH || 
-			utils.Confirm(false, "do you want to create new settings on the path you entered? (Y/n)", true) {
+			utils.Confirm(false, "Do you want to create new settings on the path you entered? (Y/n)", true) {
 			defaultSettings := Settings{}
 			err := WriteSettings(defaultSettings)
 			if err != nil {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -150,16 +150,21 @@ func ReadSettings() (Settings, error) {
 	filePath := filepath.Join(dir, settingsFilename)
 
 	// Check if the file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) { 	
+
 		// File does not exist, create it with default settings
-		defaultSettings := Settings{}
+		if config.GetPath() == config.DEFAULT_PATH || 
+			utils.Confirm(false, "do you want to create new settings on the path you entered? (Y/n)", true) {
+			defaultSettings := Settings{}
+			err := WriteSettings(defaultSettings)
+			if err != nil {
+				return Settings{}, fmt.Errorf("failed to create settings file: %w", err)
+			}
 
-		err := WriteSettings(defaultSettings)
-		if err != nil {
-			return Settings{}, fmt.Errorf("failed to create settings file: %w", err)
-		}
+			return defaultSettings, nil
+		}		
 
-		return defaultSettings, nil
+		return Settings{}, fmt.Errorf("Provide the correct path of the configuration file. Make sure the file is in .toml format.")
 	}
 
 	// Read the file
@@ -177,4 +182,3 @@ func ReadSettings() (Settings, error) {
 	return settings, nil
 }
 
-// func GetUserInfo

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -69,7 +69,10 @@ func Test_Validate(t *testing.T) {
 func Test_Save(t *testing.T) {
 	logger.New(zapcore.DebugLevel)
 
-	config.SetPath("/tmp/testazion")
+	errSetPath := config.SetPath("/tmp/testazion/test.toml")
+	if errSetPath != nil {
+		t.Fatalf("SetPath() error: %s;", errSetPath.Error())
+	}
 
 	t.Run("save token to disk", func(t *testing.T) {
 		token, err := New(&Config{


### PR DESCRIPTION
Description:
The problem is related to the question of authorization to metrics that the idea is to be asked only once, only every time you set a new configuration this question needs to be answered for the new configuration we do not make the copy for the user to have the freedom to choose if in this new configuration. The real problem was that we confused the use of the flag that receives parameters even with the flag prefix and for this reason it is asked again.

fix: checks a value with a flag smell. chaves: 'parece de tamarindo é de limão, com sabor de groselha
fix: used the path of the directory and the expected behavior is the absolute path