### PR TITLE
fix: format no milliseconds

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aziontech/team-platform-cells @aziontech/integrations
+* @aziontech/integrations

--- a/pkg/cmd/create/personal_token/expiration_date.go
+++ b/pkg/cmd/create/personal_token/expiration_date.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	msg "github.com/aziontech/azion-cli/messages/create/personal_token"
+	"github.com/aziontech/azion-cli/pkg/constants"
 )
 
 // ParseExpirationDate parses a string representation of an expiration date and returns a time.Time value representing the expiration date.
@@ -25,18 +26,16 @@ func ParseExpirationDate(currentDate time.Time, expirationString string) (time.T
 	}
 
 	// If the string contains a suffix, it is a range format
-	lastIndex := len(expirationString) - 1
-	lastChar := expirationString[lastIndex]
+	lastChar := expirationString[len(expirationString) - 1]
 	if interval, ok := suffixMapping[lastChar]; ok {
-		value := expirationString[:lastIndex]
 		intervalValue := 0
-		fmt.Sscanf(value, "%d", &intervalValue)
+		fmt.Sscanf(string(expirationString[0]), "%d", &intervalValue)
 		expirationDate := currentDate.Add(time.Duration(intervalValue) * interval)
-		return expirationDate, nil
+		return time.Parse(constants.FORMAT_DATE, expirationDate.Format(constants.FORMAT_DATE))	
 	}
 
 	// Try to analyze as full date (yyyy-mm-dd) or (dd/mm/yyyy)
-	formats := []string{"2006-01-02", "02/01/2006", "2006-01-02T00:00"}
+	formats := []string{"2006-01-02", "02/01/2006"}
 	for _, format := range formats {
 		if expirationDate, err := time.Parse(format, expirationString); err == nil {
 			if expirationDate.After(currentDate) {

--- a/pkg/cmd/create/personal_token/expiration_date_test.go
+++ b/pkg/cmd/create/personal_token/expiration_date_test.go
@@ -24,6 +24,10 @@ func TestParseExpirationDate(t *testing.T) {
 			name: "1 day", args: args{currentDate, "1d"},
 			want: time.Date(2008, 11, 02, 0, 0, 0, 0, &time.Location{})},
 		{
+			name: "1 week", args: args{time.Date(2024, 03, 06, 0, 0, 0, 0, &time.Location{}), "1w"},
+			want: time.Date(2024, 03, 13, 0, 0, 0, 0, &time.Location{}),
+		},
+		{
 			name: "2 week", args: args{currentDate, "2w"},
 			want: time.Date(2008, 11, 15, 0, 0, 0, 0, &time.Location{}),
 		},
@@ -41,10 +45,6 @@ func TestParseExpirationDate(t *testing.T) {
 		},
 		{
 			name: "Format DB", args: args{currentDate, "2008-11-04"},
-			want: time.Date(2008, 11, 04, 0, 0, 0, 0, &time.Location{}),
-		},
-		{
-			name: "Format DB - T", args: args{currentDate, "2008-11-04T00:00"},
 			want: time.Date(2008, 11, 04, 0, 0, 0, 0, &time.Location{}),
 		},
 		{

--- a/pkg/cmd/list/personal_token/personal_token.go
+++ b/pkg/cmd/list/personal_token/personal_token.go
@@ -13,6 +13,7 @@ import (
 	msg "github.com/aziontech/azion-cli/messages/list/personal_token"
 	api "github.com/aziontech/azion-cli/pkg/api/personal_token"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/constants"
 	"github.com/aziontech/azion-cli/pkg/logger"
 	"github.com/aziontech/azion-cli/utils"
 	"github.com/spf13/cobra"
@@ -77,7 +78,7 @@ func PrintTable(client *api.Client, f *cmdutil.Factory, details bool) error {
 		tbl.AddRow(
 			*v.Uuid,
 			utils.TruncateString(*v.Name),
-			*v.ExpiresAt,
+			v.ExpiresAt.Format(constants.FORMAT_DATE),
 			*v.Created,
 			utils.TruncateString(description),
 		)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -9,4 +9,5 @@ var (
 
 const (
 	PathAzionJson = "/azion/azion.json"
+	FORMAT_DATE   = "2006-01-02 15:04:05 -0700 MST"
 )


### PR DESCRIPTION
For some reason, the listing for personal tokens displayed a weird timestamp formatting for one of the items.