### PR TITLE
chore: deploy command refactor

### DIFF
--- a/messages/deploy/messages.go
+++ b/messages/deploy/messages.go
@@ -22,11 +22,16 @@ var (
 	CacheSettingsSuccessful           = "Created Cache Settings for Edge Application\n"
 	RulesEngineSuccessful             = "Created Rules Engine for Edge Application\n"
 	DeployFlagHelp                    = "Displays more information about the deploy command"
+	DeployFlagAuto                    = "If sent, the entire flow of the command will be run without interruptions"
 	DeployPropagation                 = "Your application is being deployed to all Azion Edge Locations and it might take a few minutes.\n"
 	UploadStart                       = "Uploading static files\n"
 	UploadSuccessful                  = "\nUpload completed successfully!\n"
 	BucketInUse                       = "This bucket's name is already in use, please try another one\n"
-	AskInputName                      = "Your bucket's name:"
+	AppInUse                          = "This edge application's name is already in use, please try another one\n"
+	DomainInUse                       = "This domain's name is already in use, please try another one\n"
+	FuncInUse                         = "This edge function's name is already in use, please try another one\n"
+	FuncInstInUse                     = "This function instance's name is already in use, please try another one\n"
+	AskInputName                      = "Type the new name:"
 	ProjectNameMessage                = "Using the same name as your project to create the bucket\n"
 	AskCreateCacheSettings            = `Azion CLI offers to create the following Cache Settings specifications:
   - Browser Cache Settings: Override Cache Settings

--- a/messages/link/errors.go
+++ b/messages/link/errors.go
@@ -18,6 +18,5 @@ var (
 	ErrorNpmNotInstalled               = errors.New("Failed to open the NPM package Manager. Visit the website 'https://nodejs.org/en/download/' and follow the instructions to install the Node.js JavaScript runtime environment in your operating system. Node.js installation includes the NPM package manager")
 	ErrorFailedCreatingWorkerDirectory = errors.New("Failed to create the worker directory. The worker's parent directory is read-only and/or isn't accessible. Change the permissions of the parent directory to read and write and/or give access to it")
 	ErrorFailedCreatingAzionDirectory  = errors.New("Failed to create the azion directory. The public's parent directory is read-only and/or isn't accessible. Change the permissions of the parent directory to read and write and/or give access to it")
-	ErrReadEnvFile                     = errors.New("Failed to read the webdev.env file. Verify if the file is corrupted or changed or run the 'azion edge_applications publish' command again")
 	ErrorDeps                          = errors.New("Failed to install project dependencies")
 )

--- a/pkg/api/edge_applications/edge_applications.go
+++ b/pkg/api/edge_applications/edge_applications.go
@@ -121,10 +121,6 @@ type FunctionsInstancesResponse interface {
 	GetArgs() interface{}
 }
 
-type CreateFuncInstancesRequest struct {
-	sdk.ApplicationCreateInstanceRequest
-}
-
 type CreateDeviceGroupsRequest struct {
 	sdk.CreateDeviceGroupsRequest
 }
@@ -165,30 +161,6 @@ func (c *Client) UpdateInstance(ctx context.Context, req *UpdateInstanceRequest,
 		logger.Debug("Status Code", zap.Any("http", httpResp.StatusCode))
 		logger.Debug("Headers", zap.Any("http", httpResp.Header))
 		logger.Debug("Response body", zap.Any("http", httpResp.Body))
-		return nil, utils.ErrorPerStatusCode(httpResp, err)
-	}
-
-	return edgeApplicationsResponse.Results, nil
-}
-
-func (c *Client) CreateInstancePublish(ctx context.Context, req *CreateInstanceRequest) (EdgeApplicationsResponse, error) {
-	logger.Debug("Create Instance Publish")
-	args := make(map[string]interface{})
-	req.SetArgs(args)
-
-	request := c.apiClient.EdgeApplicationsEdgeFunctionsInstancesAPI.
-		EdgeApplicationsEdgeApplicationIdFunctionsInstancesPost(ctx, req.ApplicationId).
-		ApplicationCreateInstanceRequest(req.ApplicationCreateInstanceRequest)
-
-	edgeApplicationsResponse, httpResp, err := request.Execute()
-	if err != nil {
-		if httpResp != nil {
-			logger.Debug("Error while creating an Edge Function instance", zap.Error(err))
-			err := utils.LogAndRewindBody(httpResp)
-			if err != nil {
-				return nil, err
-			}
-		}
 		return nil, utils.ErrorPerStatusCode(httpResp, err)
 	}
 
@@ -416,7 +388,7 @@ func (c *Client) DeleteFunctionInstance(ctx context.Context, appID string, funcI
 	return nil
 }
 
-func (c *Client) CreateFuncInstances(ctx context.Context, req *CreateFuncInstancesRequest, applicationID int64) (FunctionsInstancesResponse, error) {
+func (c *Client) CreateFuncInstances(ctx context.Context, req *CreateInstanceRequest, applicationID int64) (FunctionsInstancesResponse, error) {
 	logger.Debug("Create Edge Function Instance")
 	resp, httpResp, err := c.apiClient.EdgeApplicationsEdgeFunctionsInstancesAPI.EdgeApplicationsEdgeApplicationIdFunctionsInstancesPost(ctx, applicationID).
 		ApplicationCreateInstanceRequest(req.ApplicationCreateInstanceRequest).Execute()

--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -35,6 +35,7 @@ type DeployCmd struct {
 
 var (
 	Path string
+	Auto bool
 )
 
 func NewDeployCmd(f *cmdutil.Factory) *DeployCmd {
@@ -71,6 +72,7 @@ func NewCobraCmd(deploy *DeployCmd) *cobra.Command {
 	}
 	deployCmd.Flags().BoolP("help", "h", false, msg.DeployFlagHelp)
 	deployCmd.Flags().StringVar(&Path, "path", "", msg.EdgeApplicationDeployPathFlag)
+	deployCmd.Flags().BoolVar(&Auto, "auto", false, msg.DeployFlagAuto)
 	return deployCmd
 }
 

--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -65,6 +65,7 @@ func NewCobraCmd(deploy *DeployCmd) *cobra.Command {
 		Example: heredoc.Doc(`
         $ azion deploy --help
         $ azion deploy --path dist/storage
+        $ azion deploy --auto
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploy.Run(deploy.F)

--- a/pkg/cmd/deploy/manifest.go
+++ b/pkg/cmd/deploy/manifest.go
@@ -84,11 +84,6 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 		return err
 	}
 
-	domainName, err := cmd.doDomain(clients.Domain, ctx, conf)
-	if err != nil {
-		return err
-	}
-
 	var cacheID int64 = 0
 
 	for _, route := range manifest.Routes {
@@ -266,6 +261,11 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 	err = cmd.WriteAzionJsonContent(conf)
 	if err != nil {
 		logger.Debug("Error while writing azion.json file", zap.Error(err))
+		return err
+	}
+
+	domainName, err := cmd.doDomain(clients.Domain, ctx, conf)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/cmd/deploy/manifest.go
+++ b/pkg/cmd/deploy/manifest.go
@@ -89,7 +89,6 @@ func (manifest *Manifest) Interpreted(f *cmdutil.Factory, cmd *DeployCmd, conf *
 		return err
 	}
 
-	// cacheID created for "compute" in the SSR, will be used to create the function and configure the caching policy.
 	var cacheID int64 = 0
 
 	for _, route := range manifest.Routes {

--- a/pkg/cmd/deploy/requests.go
+++ b/pkg/cmd/deploy/requests.go
@@ -514,7 +514,6 @@ func (cmd *DeployCmd) createInstance(ctx context.Context, client *apiapp.Client,
 	} else {
 		reqIns.SetName(conf.Function.Name)
 	}
-	// reqIns.SetArgs()
 	reqIns.ApplicationId = conf.Application.ID
 
 	//Read args

--- a/pkg/cmd/deploy/requests.go
+++ b/pkg/cmd/deploy/requests.go
@@ -512,7 +512,7 @@ func (cmd *DeployCmd) createInstance(ctx context.Context, client *apiapp.Client,
 	if conf.Function.InstanceName == "__DEFAULT__" {
 		reqIns.SetName(conf.Name)
 	} else {
-		reqIns.SetName(conf.Function.Name)
+		reqIns.SetName(conf.Function.InstanceName)
 	}
 	reqIns.ApplicationId = conf.Application.ID
 

--- a/pkg/cmd/deploy/requests.go
+++ b/pkg/cmd/deploy/requests.go
@@ -116,18 +116,12 @@ func (cmd *DeployCmd) doApplication(client *apiapp.Client, ctx context.Context, 
 		for {
 			applicationId, err := cmd.createApplication(client, ctx, conf)
 			if err != nil {
-				fmt.Println("deu erro")
-				fmt.Println(err)
-				fmt.Println(Auto)
-				fmt.Println(errors.Is(err, utils.ErrorNameInUse))
 				// if the name is already in use, we ask for another one
 				if strings.Contains(err.Error(), utils.ErrorNameInUse.Error()) {
 					logger.FInfo(cmd.Io.Out, msg.AppInUse)
 					if Auto {
 						projName = thoth.GenerateName()
-						fmt.Println("aquiuiuiuuiui")
 					} else {
-						fmt.Println("not aqui")
 						projName, err = askForInput(msg.AskInputName, thoth.GenerateName())
 						if err != nil {
 							return err
@@ -148,7 +142,6 @@ func (cmd *DeployCmd) doApplication(client *apiapp.Client, ctx context.Context, 
 			return err
 		}
 	} else {
-		fmt.Println("cheguei aqui")
 		err := cmd.updateApplication(client, ctx, conf)
 		if err != nil {
 			logger.Debug("Error while updating Edge Application", zap.Error(err))

--- a/pkg/cmd/edge_functions_instances/create/create.go
+++ b/pkg/cmd/edge_functions_instances/create/create.go
@@ -36,7 +36,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
         $ azion edge_functions_instances create -a 1673635839 --in "create.json"
         `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			request := api.CreateFuncInstancesRequest{}
+			request := api.CreateInstanceRequest{}
 			if cmd.Flags().Changed("in") {
 				var (
 					file *os.File

--- a/pkg/cmd/init/template.go
+++ b/pkg/cmd/init/template.go
@@ -24,6 +24,7 @@ func (cmd *InitCmd) createTemplateAzion(info *InitInfo) error {
 	}
 
 	azionJson.Function.Name = "__DEFAULT__"
+	azionJson.Function.InstanceName = "__DEFAULT__"
 	azionJson.Function.File = "./out/worker.js"
 	azionJson.Function.Args = "./azion/args.json"
 	azionJson.Domain.Name = "__DEFAULT__"

--- a/pkg/cmd/link/link.go
+++ b/pkg/cmd/link/link.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aziontech/azion-cli/pkg/cmd/deploy"
 	"github.com/aziontech/azion-cli/pkg/cmd/dev"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
-	"github.com/aziontech/azion-cli/pkg/contracts"
 	"github.com/aziontech/azion-cli/pkg/iostreams"
 	"github.com/aziontech/azion-cli/pkg/logger"
 	"github.com/aziontech/azion-cli/utils"
@@ -87,7 +86,6 @@ func NewLinkCmd(f *cmdutil.Factory) *LinkCmd {
 }
 
 func NewCobraCmd(link *LinkCmd, f *cmdutil.Factory) *cobra.Command {
-	options := &contracts.AzionApplicationOptions{}
 	info := &LinkInfo{}
 	cobraCmd := &cobra.Command{
 		Use:           msg.EdgeApplicationsLinkUsage,
@@ -105,7 +103,7 @@ func NewCobraCmd(link *LinkCmd, f *cmdutil.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			info.GlobalFlagAll = f.GlobalFlagAll
-			return link.run(info, options)
+			return link.run(info)
 		},
 	}
 
@@ -121,7 +119,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewLinkCmd(f), f)
 }
 
-func (cmd *LinkCmd) run(info *LinkInfo, options *contracts.AzionApplicationOptions) error {
+func (cmd *LinkCmd) run(info *LinkInfo) error {
 	logger.Debug("Running link command")
 
 	path, err := cmd.GetWorkDir()

--- a/pkg/cmd/link/template.go
+++ b/pkg/cmd/link/template.go
@@ -24,6 +24,7 @@ func (cmd *LinkCmd) createTemplateAzion(info *LinkInfo) error {
 		Prefix:   "",
 	}
 	azionJson.Function.Name = "__DEFAULT__"
+	azionJson.Function.InstanceName = "__DEFAULT__"
 	azionJson.Function.File = "./out/worker.js"
 	azionJson.Function.Args = "./azion/args.json"
 	azionJson.Domain.Name = "__DEFAULT__"

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -86,11 +86,12 @@ type CacheConf struct {
 }
 
 type AzionJsonDataFunction struct {
-	ID         int64  `json:"id"`
-	Name       string `json:"name"`
-	File       string `json:"file"`
-	Args       string `json:"args"`
-	InstanceID int64  `json:"instance-id"`
+	ID           int64  `json:"id"`
+	Name         string `json:"name"`
+	File         string `json:"file"`
+	Args         string `json:"args"`
+	InstanceID   int64  `json:"instance-id"`
+	InstanceName string `json:"instance-name"`
 }
 
 type AzionJsonDataApplication struct {

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -29,6 +29,10 @@ import (
 
 const shell = "/bin/sh"
 
+var (
+	NameTaken = []string{"already taken", "name taken", "name already in use", "already in use", "already exists", "with the name", "409 Conflict"}
+)
+
 func CleanDirectory(dir string) error {
 
 	err := os.RemoveAll(dir)
@@ -298,6 +302,9 @@ func ErrorPerStatusCode(httpResp *http.Response, err error) error {
 	case 404:
 		return ErrorNotFound404
 
+	case 409:
+		return ErrorNameInUse
+
 	default:
 		return err
 
@@ -368,7 +375,7 @@ func checkTlsVersion(body string) error {
 }
 
 func checkNameInUse(body string) error {
-	if strings.Contains(body, "name_already_in_use") || strings.Contains(body, "bucket name is already in use") {
+	if strings.Contains(body, "name_already_in_use") || strings.Contains(body, "bucket name is already in use") || containsErrorMessageNameTaken(body) {
 		return ErrorNameInUse
 	}
 	return nil
@@ -631,4 +638,13 @@ func Format(input string) (int, error) {
 
 	return number, nil
 
+}
+
+func containsErrorMessageNameTaken(msg string) bool {
+	for _, phrase := range NameTaken {
+		if strings.Contains(msg, phrase) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- Always retry when name is already taken for resources creation.
- `--auto` flag:
  - This flag will make sure the flow is not interrupted and will run deploy command to its completion. It will automatically give a new name in case the original name used is repeated. 
- Update Instance args.json on deploy.