### PR TITLE
chore: add timestamp to domain name

### DIFF
--- a/messages/deploy/messages.go
+++ b/messages/deploy/messages.go
@@ -45,4 +45,5 @@ Do you wish to create a Cache Settings configuration with the above specificatio
 	SkipUpload           = "Your project does not contain a '.edge/storage' folder. Skipping upload of static files"
 	NameInUseBucket      = "Bucket name is already in use. Trying to create bucket with the following name: %s\n"
 	NameInUseApplication = "Edge Application name is already in use. Trying to create Edge Application with the following name: %s\n"
+	NameInUseDomain      = "Domain name is already in use. Trying to create Domain with the following name: %s\n"
 )

--- a/pkg/cmd/deploy/requests.go
+++ b/pkg/cmd/deploy/requests.go
@@ -128,7 +128,6 @@ func (cmd *DeployCmd) doApplication(client *apiapp.Client, ctx context.Context, 
 							return err
 						}
 					}
-					conf.Application.Name = projName
 					conf.Name = projName
 					continue
 				}

--- a/pkg/cmd/deploy/requests.go
+++ b/pkg/cmd/deploy/requests.go
@@ -129,6 +129,7 @@ func (cmd *DeployCmd) doApplication(client *apiapp.Client, ctx context.Context, 
 						}
 					}
 					conf.Application.Name = projName
+					conf.Name = projName
 					continue
 				}
 				return err
@@ -169,6 +170,8 @@ func (cmd *DeployCmd) doDomain(client *apidom.Client, ctx context.Context, conf 
 					}
 					logger.FInfo(cmd.Io.Out, msg.DomainInUse)
 					if Auto {
+						projName = fmt.Sprintf("%s-%s", conf.Name, utils.Timestamp())
+						logger.FInfo(cmd.Io.Out, fmt.Sprintf(msg.NameInUseApplication, projName))
 						projName = thoth.GenerateName()
 					} else {
 						projName, err = askForInput(msg.AskInputName, thoth.GenerateName())

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aziontech/azion-cli/pkg/logger"
 	"github.com/aziontech/azion-cli/utils"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 var (
@@ -72,15 +71,7 @@ func (cmd *DevCmd) Run(f *cmdutil.Factory) error {
 		contract.OwnWorker = "true"
 	}
 
-	// Run build command
-	build := cmd.BuildCmd(f)
-	err := build.Run(contract)
-	if err != nil {
-		logger.Debug("Error while running build command called by dev command", zap.Error(err))
-		return err
-	}
-
-	err = vulcan(cmd, isFirewall)
+	err := vulcan(cmd, isFirewall)
 	if err != nil {
 		return err
 	}

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -646,5 +646,5 @@ func containsErrorMessageNameTaken(msg string) bool {
 }
 
 func Timestamp() string {
-	return fmt.Sprintf("%d", time.Now().Unix())
+	return time.Now().Format("20060102150405")
 }


### PR DESCRIPTION
- Revert timestamp back to old format, as it was the same used in frontend;
- Remove build from dev command (Vulcan runs build prior to dev now);
- Add timestamp to domain name in case name is already in use;