### PR TITLE
feat: add sync command [rules engine only]

### DIFF
--- a/messages/sync/errors.go
+++ b/messages/sync/errors.go
@@ -1,0 +1,5 @@
+package sync
+
+var (
+	ERRORSYNC = "Failed to synchronize local resources with remote resources: %s"
+)

--- a/messages/sync/messages.go
+++ b/messages/sync/messages.go
@@ -1,0 +1,9 @@
+package sync
+
+const (
+	USAGE            = "sync"
+	SHORTDESCRIPTION = "Synchronizes local azion.json file with remote resources"
+	LONGDESCRIPTION  = "Synchronizes your local file containing your created resources with remote resources"
+	SYNCMESSAGERULE  = "Adding out of sync rule '%s' to your azion.json file\n"
+	HELPFLAG         = "Displays more information about the sync command"
+)

--- a/messages/sync/messages.go
+++ b/messages/sync/messages.go
@@ -3,7 +3,7 @@ package sync
 const (
 	USAGE            = "sync"
 	SHORTDESCRIPTION = "Synchronizes the local azion.json file with remote resources"
-	LONGDESCRIPTION  = "Synchronizes your local file containing your created resources with remote resources"
+	LONGDESCRIPTION  = "Synchronizes your local file containing your existing application resources configuration with remote resources"
 	SYNCMESSAGERULE  = "Adding out of sync rule '%s' to your azion.json file\n"
 	HELPFLAG         = "Displays more information about the sync command"
 )

--- a/messages/sync/messages.go
+++ b/messages/sync/messages.go
@@ -2,7 +2,7 @@ package sync
 
 const (
 	USAGE            = "sync"
-	SHORTDESCRIPTION = "Synchronizes local azion.json file with remote resources"
+	SHORTDESCRIPTION = "Synchronizes the local azion.json file with remote resources"
 	LONGDESCRIPTION  = "Synchronizes your local file containing your created resources with remote resources"
 	SYNCMESSAGERULE  = "Adding out of sync rule '%s' to your azion.json file\n"
 	HELPFLAG         = "Displays more information about the sync command"

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	logcmd "github.com/aziontech/azion-cli/pkg/cmd/logs"
 	"github.com/aziontech/azion-cli/pkg/cmd/purge"
 	"github.com/aziontech/azion-cli/pkg/cmd/reset"
+	"github.com/aziontech/azion-cli/pkg/cmd/sync"
 	"github.com/aziontech/azion-cli/pkg/cmd/unlink"
 	"github.com/aziontech/azion-cli/pkg/cmd/update"
 	"github.com/aziontech/azion-cli/pkg/cmd/whoami"
@@ -151,6 +152,7 @@ func NewCobraCmd(rootCmd *RootCmd, f *cmdutil.Factory) *cobra.Command {
 	cobraCmd.AddCommand(whoami.NewCmd(f))
 	cobraCmd.AddCommand(purge.NewCmd(f))
 	cobraCmd.AddCommand(reset.NewCmd(f))
+	cobraCmd.AddCommand(sync.NewCmd(f))
 
 	return cobraCmd
 }

--- a/pkg/cmd/sync/sync.go
+++ b/pkg/cmd/sync/sync.go
@@ -12,10 +12,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	isFirewall bool
-)
-
 type SyncCmd struct {
 	Io                    *iostreams.IOStreams
 	GetAzionJsonContent   func() (*contracts.AzionApplicationOptions, error)

--- a/pkg/cmd/sync/sync.go
+++ b/pkg/cmd/sync/sync.go
@@ -1,0 +1,83 @@
+package sync
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	msg "github.com/aziontech/azion-cli/messages/sync"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/contracts"
+	"github.com/aziontech/azion-cli/pkg/iostreams"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/aziontech/azion-cli/utils"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var (
+	isFirewall bool
+)
+
+type SyncCmd struct {
+	Io                    *iostreams.IOStreams
+	GetAzionJsonContent   func() (*contracts.AzionApplicationOptions, error)
+	WriteAzionJsonContent func(conf *contracts.AzionApplicationOptions) error
+	F                     *cmdutil.Factory
+}
+
+func NewDevCmd(f *cmdutil.Factory) *SyncCmd {
+	return &SyncCmd{
+		F:                     f,
+		Io:                    f.IOStreams,
+		GetAzionJsonContent:   utils.GetAzionJsonContent,
+		WriteAzionJsonContent: utils.WriteAzionJsonContent,
+	}
+}
+
+func NewCobraCmd(sync *SyncCmd) *cobra.Command {
+	syncCmd := &cobra.Command{
+		Use:           msg.USAGE,
+		Short:         msg.SHORTDESCRIPTION,
+		Long:          msg.LONGDESCRIPTION,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Example: heredoc.Doc(`       
+        $ azion sync
+        $ azion sync --help
+        `),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sync.Run(sync.F)
+		},
+	}
+	syncCmd.Flags().BoolP("help", "h", false, msg.HELPFLAG)
+	return syncCmd
+}
+
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	return NewCobraCmd(NewDevCmd(f))
+}
+
+func (cmd *SyncCmd) Run(f *cmdutil.Factory) error {
+	logger.Debug("Running sync command")
+
+	conf, err := cmd.GetAzionJsonContent()
+	if err != nil {
+		logger.Debug("Failed to get Azion JSON content", zap.Error(err))
+		return err
+	}
+
+	ruleIds := make(map[string]int64)
+	for _, ruleConf := range conf.RulesEngine.Rules {
+		ruleIds[ruleConf.Name] = ruleConf.Id
+	}
+
+	info := contracts.SyncOpts{
+		RuleIds: ruleIds,
+		Conf:    conf,
+	}
+
+	err = cmd.SyncResources(f, info)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/sync/tasks.go
+++ b/pkg/cmd/sync/tasks.go
@@ -1,0 +1,59 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	msg "github.com/aziontech/azion-cli/messages/sync"
+	api "github.com/aziontech/azion-cli/pkg/api/edge_applications"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/contracts"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"go.uber.org/zap"
+)
+
+var (
+	C    context.Context
+	Opts *contracts.ListOptions
+)
+
+func (synch *SyncCmd) SyncResources(f *cmdutil.Factory, info contracts.SyncOpts) error {
+	C = context.Background()
+	Opts = &contracts.ListOptions{
+		PageSize: 1000,
+		Page:     1,
+	}
+	err := synch.syncRules(info, f)
+	if err != nil {
+		return fmt.Errorf(msg.ERRORSYNC, err.Error())
+	}
+	return nil
+}
+
+func (synch *SyncCmd) syncRules(info contracts.SyncOpts, f *cmdutil.Factory) error {
+
+	client := api.NewClient(f.HttpClient, f.Config.GetString("api_url"), f.Config.GetString("token"))
+	resp, err := client.ListRulesEngine(C, Opts, info.Conf.Application.ID, "request")
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range resp.Results {
+		if id := info.RuleIds[rule.Name]; id > 0 || rule.Name == "Default Rule" {
+			// if remote rule is also on local environment, no action is needed
+			continue
+		}
+		newRule := contracts.AzionJsonDataRules{
+			Id:   rule.GetId(),
+			Name: rule.GetName(),
+		}
+		info.Conf.RulesEngine.Rules = append(info.Conf.RulesEngine.Rules, newRule)
+		err := synch.WriteAzionJsonContent(info.Conf)
+		if err != nil {
+			logger.Debug("Error while writing azion.json file", zap.Error(err))
+			return err
+		}
+		logger.FInfo(synch.Io.Out, fmt.Sprintf(msg.SYNCMESSAGERULE, rule.Name))
+	}
+	return nil
+}

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -196,3 +196,8 @@ type RulesEngineBehaviorEntry struct {
 	RulesEngineBehaviorObject *sdk.RulesEngineBehaviorObject
 	RulesEngineBehaviorString *sdk.RulesEngineBehaviorString
 }
+
+type SyncOpts struct {
+	RuleIds map[string]int64
+	Conf    *AzionApplicationOptions
+}


### PR DESCRIPTION
**WHAT**
- Add sync command:
  - This will check if there are rules engine created remotely that are not found in local azion.json file, and add them. 

TO DO [Future PRs]:
- Add sync to other resources;
- Add this flow to deploy command;