### PR TITLE
fix: check if .edge/storage exists before purging files

### DIFF
--- a/pkg/cmd/deploy/purge.go
+++ b/pkg/cmd/deploy/purge.go
@@ -53,6 +53,9 @@ func (cmd *DeployCmd) PurgeUrls(domain []string, path string) error {
 }
 
 func PurgeForUpdatedFiles(cmd *DeployCmd, domain apidom.DomainResponse, confPath string, msgs *[]string) error {
+	if _, err := os.Stat(PathStatic); os.IsNotExist(err) {
+		return nil
+	}
 	listURLsDomains := domain.GetCnames()
 	if !domain.GetCnameAccessOnly() {
 		listURLsDomains = append(listURLsDomains, domain.GetDomainName())

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -36,6 +36,7 @@ func NewDevCmd(f *cmdutil.Factory) *DevCmd {
 		CommandRunInteractive: func(f *cmdutil.Factory, comm string) error {
 			return utils.CommandRunInteractive(f, comm)
 		},
+		Vulcan: vulcanPkg.NewVulcan,
 	}
 }
 


### PR DESCRIPTION
**WHAT**
- fix: check if .edge/storage directory exists before reading it to purge files;
- fix: initialize structure with vulcan value in dev command;