### PR TITLE
docs: improve sync error message when not deployed

### DIFF
--- a/messages/init/messages.go
+++ b/messages/init/messages.go
@@ -19,7 +19,7 @@ var (
 	WebAppInitContentOverridden           = "This application was already configured. Do you want to override the previous configuration? <yes | no> (default: no) "
 	WebAppInitCmdSuccess                  = "Template successfully fetched and configured\n"
 	InitGettingTemplates                  = "\nGetting modes available (Some dependencies may need to be installed)\n"
-	InitGettingVulcan                     = "Getting templates available\n"
+	InitGettingVulcan                     = "\nGetting templates available\n"
 	InitProjectQuestion                   = "Your application's name: "
 	EdgeApplicationsInitFlagHelp          = "Displays more information about the init command"
 	EdgeApplicationsInitSuccessful        = "Your application %s was initialized successfully\n"

--- a/messages/sync/errors.go
+++ b/messages/sync/errors.go
@@ -1,5 +1,8 @@
 package sync
 
+import "errors"
+
 var (
-	ERRORSYNC = "Failed to synchronize local resources with remote resources: %s"
+	ERRORSYNC        = "Failed to synchronize local resources with remote resources: %s"
+	ERRORNOTDEPLOYED = errors.New("Failed to synchronize local resources with remote resources: You must deploy your project at least once before trying to synchronize with remote resources")
 )

--- a/pkg/cmd/sync/tasks.go
+++ b/pkg/cmd/sync/tasks.go
@@ -25,6 +25,10 @@ func SyncLocalResources(f *cmdutil.Factory, info contracts.SyncOpts, synch *Sync
 		Page:     1,
 	}
 
+	if info.Conf.Application.ID <= 0 {
+		return msg.ERRORNOTDEPLOYED
+	}
+
 	var err error
 	err = synch.syncRules(info, f)
 	if err != nil {


### PR DESCRIPTION
**WHAT**
- Display message explaining that the user needs to deploy their project at least once before trying to sync;