### PR TITLE
fix: invalid cross-device link

### DIFF
--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aziontech/azion-cli/pkg/cmd/deploy"
 	"github.com/aziontech/azion-cli/pkg/cmd/dev"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/config"
 	"github.com/aziontech/azion-cli/pkg/github"
 	"github.com/aziontech/azion-cli/pkg/iostreams"
 	"github.com/aziontech/azion-cli/pkg/logger"
@@ -202,8 +203,13 @@ func (cmd *initCmd) Run(c *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Create a temporary directory
-	tempDir, err := os.MkdirTemp("", "tempclonesamples")
+	dirPath, err := config.Dir()
+	if err != nil {
+		return err
+	}
+
+	// Create a temporary directory	
+	tempDir, err := os.MkdirTemp(dirPath.Dir, "tempclonesamples")
 	if err != nil {
 		return err
 	}
@@ -223,9 +229,13 @@ func (cmd *initCmd) Run(c *cobra.Command, _ []string) error {
 		return err
 	}
 
+	oldPath := path.Join(tempDir, "templates", templateOptionsMap[answerTemplate].Path)
+	newPath := path.Join(pathWorkingDirHere, cmd.name)
+
 	//move contents from temporary directory into final destination
-	err = cmd.rename(path.Join(tempDir, "templates", templateOptionsMap[answerTemplate].Path), path.Join(pathWorkingDirHere, cmd.name))
+	err = cmd.rename(oldPath, newPath)
 	if err != nil {
+		logger.Debug("Error move contents directory", zap.Error(err))
 		return utils.ErrorMovingFiles
 	}
 

--- a/pkg/vulcan/vulcan.go
+++ b/pkg/vulcan/vulcan.go
@@ -16,10 +16,10 @@ import (
 const (
 	currentMajor         = 3
 	installEdgeFunctions = "npx --yes %s edge-functions%s %s"
-	firstTimeExecuting   = "@v3.0.0"
+	firstTimeExecuting   = "@v3.1.0"
 )
 
-var versionVulcan = "@3.0.0"
+var versionVulcan = "@3.1.0"
 
 type VulcanPkg struct {
 	Command          func(flags, params string, f *cmdutil.Factory) string

--- a/pkg/vulcan/vulcan.go
+++ b/pkg/vulcan/vulcan.go
@@ -16,10 +16,10 @@ import (
 const (
 	currentMajor         = 3
 	installEdgeFunctions = "npx --yes %s edge-functions%s %s"
-	firstTimeExecuting   = "@v3.1.0"
+	firstTimeExecuting   = "@v3.2.0"
 )
 
-var versionVulcan = "@3.1.0"
+var versionVulcan = "@3.2.0"
 
 type VulcanPkg struct {
 	Command          func(flags, params string, f *cmdutil.Factory) string

--- a/pkg/vulcan/vulcan_test.go
+++ b/pkg/vulcan/vulcan_test.go
@@ -116,17 +116,17 @@ func TestCheckVulcanMajor(t *testing.T) {
 			args: args{
 				currentVersion: "4.0.0",
 			},
-			lastVulcanVer:   "3.0.0",
-			expectedVersion: "@v3.0.0",
+			lastVulcanVer:   "3.1.0",
+			expectedVersion: "@v3.1.0",
 			wantErr:         false,
 		},
 		{
 			name: "same major version",
 			args: args{
-				currentVersion: "3.0.0",
+				currentVersion: "3.1.0",
 			},
-			lastVulcanVer:   "3.0.0",
-			expectedVersion: "@v3.0.0",
+			lastVulcanVer:   "3.1.0",
+			expectedVersion: "@v3.1.0",
 			wantErr:         false,
 		},
 		{

--- a/pkg/vulcan/vulcan_test.go
+++ b/pkg/vulcan/vulcan_test.go
@@ -116,17 +116,17 @@ func TestCheckVulcanMajor(t *testing.T) {
 			args: args{
 				currentVersion: "4.0.0",
 			},
-			lastVulcanVer:   "3.1.0",
-			expectedVersion: "@v3.1.0",
+			lastVulcanVer:   "3.2.0",
+			expectedVersion: "@v3.2.0",
 			wantErr:         false,
 		},
 		{
 			name: "same major version",
 			args: args{
-				currentVersion: "3.1.0",
+				currentVersion: "3.2.0",
 			},
-			lastVulcanVer:   "3.1.0",
-			expectedVersion: "@v3.1.0",
+			lastVulcanVer:   "3.2.0",
+			expectedVersion: "@v3.2.0",
 			wantErr:         false,
 		},
 		{


### PR DESCRIPTION
The `os.Rename` method in Go, as in many other systems, is most efficient when the file or directory is being moved within the same file system. When you try to move files between different file systems, such as from `/tmp`  to the working directory, the rename command cannot be used and results in an error.

On many Linux systems, the `/tmp` directory may be on a separate partition or device from the one where the destination directory is located. However, on macOS, this may not be a problem if the `/tmp` directory and the target directory are on the same file system.