### PR TITLE
chore: forward auto flag to deploy remote

### DIFF
--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -150,7 +150,7 @@ func (cmd *DeployCmd) Run(f *cmdutil.Factory) error {
 
 	if Local {
 		deployLocal := deploy.NewDeployCmd(f)
-		return deployLocal.ExternalRun(f, ProjectConf, Sync)
+		return deployLocal.ExternalRun(f, ProjectConf, Env, Sync, Auto, SkipBuild)
 	}
 
 	msgs := []string{}

--- a/pkg/cmd/deploy_remote/deploy.go
+++ b/pkg/cmd/deploy_remote/deploy.go
@@ -97,9 +97,12 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewDeployCmd(f))
 }
 
-func (cmd *DeployCmd) ExternalRun(f *cmdutil.Factory, configPath string, shouldSync bool) error {
+func (cmd *DeployCmd) ExternalRun(f *cmdutil.Factory, configPath string, env string, shouldSync, auto, skipBuild bool) error {
 	ProjectConf = configPath
 	Sync = shouldSync
+	Env = env
+	Auto = auto
+	SkipBuild = skipBuild
 	return cmd.Run(f)
 }
 

--- a/pkg/cmd/deploy_remote/requests.go
+++ b/pkg/cmd/deploy_remote/requests.go
@@ -106,11 +106,7 @@ func (cmd *DeployCmd) doFunction(clients *Clients, ctx context.Context, conf *co
 	return nil
 }
 
-func (cmd *DeployCmd) doApplication(
-	client *apiapp.Client,
-	ctx context.Context,
-	conf *contracts.AzionApplicationOptions,
-	msgs *[]string) error {
+func (cmd *DeployCmd) doApplication(client *apiapp.Client, ctx context.Context, conf *contracts.AzionApplicationOptions, msgs *[]string) error {
 	if conf.Application.ID == 0 {
 		var projName string
 		for {


### PR DESCRIPTION
**WHAT**
- Forward auto flag to the deploy-remote command;
  - This allows deploys from automated environments (such as script-runner) to use this feature;