### PR TITLE
feat(warmup): add cache warming command with URL crawling

### DIFF
--- a/messages/warmup/errors.go
+++ b/messages/warmup/errors.go
@@ -1,0 +1,10 @@
+package warmup
+
+import "errors"
+
+var (
+	ErrorInvalidUrl        = errors.New("Invalid URL provided. URL must be a valid HTTP/HTTPS URL")
+	ErrorMaxUrlsExceeded   = errors.New("Maximum number of URLs exceeded")
+	ErrorRequestTimeout    = errors.New("Request timed out")
+	ErrorProcessingFailed  = errors.New("Failed to process URL")
+) 

--- a/messages/warmup/messages.go
+++ b/messages/warmup/messages.go
@@ -1,0 +1,32 @@
+package warmup
+
+var (
+	Usage            = "warmup"
+	ShortDescription = "Preload URLs into edge cache"
+	LongDescription  = "Performs cache warming by systematically crawling a URL and preloading its content into the edge cache"
+	FlagHelp         = "Displays more information about the warmup command"
+	FlagUrl          = "Base URL to start warming the cache"
+	FlagMaxUrls      = "Maximum number of URLs to process (default: 1500)"
+	FlagMaxConcurrent = "Maximum number of concurrent requests (default: 2)"
+	FlagTimeout      = "Timeout in milliseconds for each request (default: 8000)"
+	WarmupSuccessful = "Cache warming completed successfully"
+	AskForUrl        = "Enter the base URL to warm cache (e.g., https://example.com):"
+	
+	// Log messages
+	LogInitializing   = "\nInitializing cache warming"
+	LogSite           = "Target site"
+	LogConfiguration  = "Configuration"
+	LogTimeout        = "Request timeout"
+	LogBatchProcess   = "\nProcessing batch"
+	LogAddedToQueue   = "\nAdded to queue"
+	LogStatus         = "Status"
+	LogCompleted      = "\nCOMPLETED"
+	LogProcessed      = "URLs processed"
+	LogSuccessful     = "Successful"
+	LogFailed         = "Failed"
+	LogTotalTime      = "Total time"
+	LogSpeed          = "Speed"
+	LogFailedUrls     = "Failed URLs"
+	LogFoundLinks     = "\nFound links"
+	LogLinkExamples   = "Examples"
+) 

--- a/messages/warmup/messages.go
+++ b/messages/warmup/messages.go
@@ -9,7 +9,7 @@ var (
 	FlagMaxUrls      = "Maximum number of URLs to process (default: 1500)"
 	FlagMaxConcurrent = "Maximum number of concurrent requests (default: 2)"
 	FlagTimeout      = "Timeout in milliseconds for each request (default: 8000)"
-	WarmupSuccessful = "Cache warming completed successfully"
+	WarmupSuccessful = "Cache warming completed successfully!"
 	AskForUrl        = "Enter the base URL to warm cache (e.g., https://example.com):"
 	
 	// Log messages

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aziontech/azion-cli/pkg/cmd/sync"
 	"github.com/aziontech/azion-cli/pkg/cmd/unlink"
 	"github.com/aziontech/azion-cli/pkg/cmd/update"
+	"github.com/aziontech/azion-cli/pkg/cmd/warmup"
 	"github.com/aziontech/azion-cli/pkg/cmd/whoami"
 	"github.com/aziontech/azion-cli/pkg/metric"
 	"github.com/aziontech/azion-cli/pkg/output"
@@ -126,6 +127,7 @@ func (fact *factoryRoot) setCmds(cobraCmd *cobra.Command) {
 	cobraCmd.AddCommand(reset.NewCmd(fact.factory))
 	cobraCmd.AddCommand(sync.NewCmd(fact.factory))
 	cobraCmd.AddCommand(rollback.NewCmd(fact.factory))
+	cobraCmd.AddCommand(warmup.NewCmd(fact.factory))
 }
 
 func (fact *factoryRoot) CmdRoot() cmdutil.Command {

--- a/pkg/cmd/warmup/fixtures/html_sample.json
+++ b/pkg/cmd/warmup/fixtures/html_sample.json
@@ -1,0 +1,3 @@
+{
+    "html": "<!DOCTYPE html><html><head><title>Test Page</title></head><body><a href=\"/page1\">Page 1</a><a href=\"/page2\">Page 2</a><a href=\"https://external.com\">External</a><a href=\"/image.jpg\">Image</a></body></html>"
+} 

--- a/pkg/cmd/warmup/fixtures/response.json
+++ b/pkg/cmd/warmup/fixtures/response.json
@@ -1,0 +1,3 @@
+{
+    "detail": "Cache warming request processed successfully"
+} 

--- a/pkg/cmd/warmup/requests.go
+++ b/pkg/cmd/warmup/requests.go
@@ -1,0 +1,571 @@
+package warmup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	msg "github.com/aziontech/azion-cli/messages/warmup"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// Cache para URLs já visitadas e que falharam
+type urlCache struct {
+	sync.RWMutex
+	visited map[string]bool
+	failed  map[string]bool
+}
+
+func newUrlCache() *urlCache {
+	return &urlCache{
+		visited: make(map[string]bool),
+		failed:  make(map[string]bool),
+	}
+}
+
+func (c *urlCache) isVisited(url string) bool {
+	c.RLock()
+	defer c.RUnlock()
+	return c.visited[url]
+}
+
+func (c *urlCache) markVisited(url string) {
+	c.Lock()
+	defer c.Unlock()
+	c.visited[url] = true
+}
+
+func (c *urlCache) markFailed(url string) {
+	c.Lock()
+	defer c.Unlock()
+	c.failed[url] = true
+}
+
+func (c *urlCache) failedCount() int {
+	c.RLock()
+	defer c.RUnlock()
+	return len(c.failed)
+}
+
+func (c *urlCache) failedURLs() []string {
+	c.RLock()
+	defer c.RUnlock()
+	urls := make([]string, 0, len(c.failed))
+	for url := range c.failed {
+		urls = append(urls, url)
+	}
+	return urls
+}
+var blacklist = []string{
+	".pdf", ".zip", ".rar", ".7z", ".tar", ".gz",
+	".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+	".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm",
+	".mp3", ".wav", ".ogg", ".m4a", ".aac",
+	"mailto:", "tel:", "sms:", "ftp:", "file:",
+	"javascript:", "data:", "#",
+}
+
+// Função auxiliar para formatar mensagens de log
+func formatLog(format string, args ...interface{}) string {
+	return fmt.Sprintf(format, args...)
+}
+
+// Realiza o warmup do cache a partir da URL base
+func warmupCache(ctx context.Context, baseUrl string, maxUrls int, maxConcurrent int, timeout int, f *cmdutil.Factory) error {
+	// Validar URL
+	_, err := url.Parse(baseUrl)
+	if err != nil {
+		return msg.ErrorInvalidUrl
+	}
+
+	// Inicializar cache de URLs
+	cache := newUrlCache()
+	pendingUrls := make([]string, 0)
+	pendingUrls = append(pendingUrls, baseUrl)
+
+	// Estatísticas
+	totalProcessed := 0
+	startTime := time.Now()
+
+	// Cabeçalho inicial
+	logger.FInfo(f.IOStreams.Out, "\nInitializing cache warming...\n")
+	logger.FInfo(f.IOStreams.Out, formatLog("Target site: %s\n", baseUrl))
+	logger.FInfo(f.IOStreams.Out, formatLog("Configuration: %d concurrent requests, max %d URLs\n", maxConcurrent, maxUrls))
+	logger.FInfo(f.IOStreams.Out, formatLog("Request timeout: %dms\n", timeout))
+	logger.FInfo(f.IOStreams.Out, "\n")
+
+	// Iniciar o processamento em lotes
+	for len(pendingUrls) > 0 && totalProcessed < maxUrls {
+		// Limita o tamanho do lote ao número de URLs pendentes ou ao máximo de concorrência
+		batchSize := min(len(pendingUrls), maxConcurrent)
+		currentBatch := pendingUrls[:batchSize]
+		pendingUrls = pendingUrls[batchSize:]
+
+		logger.FInfo(f.IOStreams.Out, formatLog("Processing batch: %d URLs (%d remaining in queue)\n", batchSize, len(pendingUrls)))
+
+		// Criar wait group para sincronizar o processamento em paralelo
+		var wg sync.WaitGroup
+		var mutex sync.Mutex // Para proteger a lista de pendingUrls durante atualizações concorrentes
+		var logMutex sync.Mutex // Para sincronizar as mensagens de log
+		newLinks := 0
+
+		// Processar cada URL do lote em paralelo
+		for _, currentUrl := range currentBatch {
+			wg.Add(1)
+
+			go func(url string) {
+				defer wg.Done()
+
+				// Processar URL e obter novos links
+				links, err := processURL(url, timeout, cache, totalProcessed, maxUrls, baseUrl, f.IOStreams.Out, &logMutex)
+				if err != nil {
+					logger.Debug("Error processing URL", zap.String("url", url), zap.Error(err))
+					cache.markFailed(url)
+					return
+				}
+
+				// Filtrar apenas os links não visitados
+				var newValidLinks []string
+				for _, link := range links {
+					if !cache.isVisited(link) && !contains(pendingUrls, link) {
+						newValidLinks = append(newValidLinks, link)
+					}
+				}
+
+				// Adicionar novos links à lista de pendentes
+				if len(newValidLinks) > 0 {
+					mutex.Lock()
+					pendingUrls = append(pendingUrls, newValidLinks...)
+					newLinks += len(newValidLinks)
+					mutex.Unlock()
+				}
+			}(currentUrl)
+		}
+
+		// Aguardar todas as goroutines terminarem
+		wg.Wait()
+		totalProcessed += batchSize
+
+		if newLinks > 0 {
+			logger.FInfo(f.IOStreams.Out, formatLog("Added to queue: %d new URLs\n", newLinks))
+		}
+
+		// Status após cada lote
+		logger.FInfo(f.IOStreams.Out, formatLog("Status: %d processed | %d queued | %d failed\n\n", totalProcessed, len(pendingUrls), cache.failedCount()))
+
+		// Pequeno delay entre lotes para não sobrecarregar
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Estatísticas finais
+	duration := time.Since(startTime)
+	logger.FInfo(f.IOStreams.Out, "COMPLETED!\n")
+	logger.FInfo(f.IOStreams.Out, formatLog("Processed: %d URLs\n", totalProcessed))
+	logger.FInfo(f.IOStreams.Out, formatLog("Successful: %d\n", totalProcessed-cache.failedCount()))
+	logger.FInfo(f.IOStreams.Out, formatLog("Failed: %d\n", cache.failedCount()))
+	logger.FInfo(f.IOStreams.Out, formatLog("Total time: %.1fs\n", duration.Seconds()))
+	
+	if totalProcessed > 0 {
+		logger.FInfo(f.IOStreams.Out, formatLog("Speed: %.1f URLs/s\n", float64(totalProcessed)/duration.Seconds()))
+	}
+
+	// Mostrar URLs que falharam (limitado a 10)
+	failedURLs := cache.failedURLs()
+	if len(failedURLs) > 0 && len(failedURLs) <= 10 {
+		logger.FInfo(f.IOStreams.Out, "\nFailed URLs:\n")
+		for _, u := range failedURLs {
+			logger.FInfo(f.IOStreams.Out, formatLog("  - %s\n", formatURL(u, baseUrl)))
+		}
+	}
+
+	return nil
+}
+
+// Processar uma URL e extrair links
+func processURL(currentURL string, timeoutMs int, cache *urlCache, processed int, maxUrls int, baseURL string, out io.Writer, logMutex *sync.Mutex) ([]string, error) {
+	if cache.isVisited(currentURL) || processed >= maxUrls {
+		return nil, nil
+	}
+
+	cache.markVisited(currentURL)
+
+	shortURL := formatURL(currentURL, baseURL)
+	
+	// Sincronizar a saída de log
+	logMutex.Lock()
+	logger.FInfo(out, formatLog("[%d/%d] %s\n", processed+1, maxUrls, shortURL))
+	logMutex.Unlock()
+
+	// Fazer requisição com timeout
+	client := &http.Client{
+		Timeout: time.Duration(timeoutMs) * time.Millisecond,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, currentURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Adicionar headers
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Connection", "keep-alive")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	// Ler o conteúdo da página
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extrair e processar links
+	links := extractLinks(string(body), baseURL, out, logMutex)
+	return links, nil
+}
+
+// Extrai links de uma página HTML usando regex mais abrangente
+func extractLinks(html, baseURL string, out io.Writer, logMutex *sync.Mutex) []string {
+	foundLinks := make(map[string]bool)
+	
+	// 1. Links tradicionais <a href>
+	linkRegex := regexp.MustCompile(`<a[^>]+href=["']([^"']+)["'][^>]*>`)
+	matches := linkRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 2. Formulários <form action>
+	formRegex := regexp.MustCompile(`<form[^>]+action=["']([^"']+)["'][^>]*>`)
+	matches = formRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 3. Recursos CSS e JS (importantes para cache)
+	cssRegex := regexp.MustCompile(`<link[^>]+href=["']([^"']+\.css[^"']*)["'][^>]*>`)
+	matches = cssRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	jsRegex := regexp.MustCompile(`<script[^>]+src=["']([^"']+\.js[^"']*)["'][^>]*>`)
+	matches = jsRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 4. Meta refresh redirects
+	metaRegex := regexp.MustCompile(`<meta[^>]+http-equiv=["']refresh["'][^>]+content=["'][^;]*;\s*url=([^"']+)["'][^>]*>`)
+	matches = metaRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 5. Canonical URLs
+	canonicalRegex := regexp.MustCompile(`<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["'][^>]*>`)
+	matches = canonicalRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 6. Imagens (importantes para cache!)
+	imgRegex := regexp.MustCompile(`<img[^>]+src=["']([^"']+)["'][^>]*>`)
+	matches = imgRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 7. Favicons e ícones
+	iconRegex := regexp.MustCompile(`<link[^>]+rel=["'](?:icon|shortcut icon|apple-touch-icon)["'][^>]+href=["']([^"']+)["'][^>]*>`)
+	matches = iconRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 8. Fontes web
+	fontRegex := regexp.MustCompile(`@font-face[^}]*url\(["']?([^"')]+)["']?\)`)
+	matches = fontRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// 9. Background images em CSS inline
+	bgRegex := regexp.MustCompile(`background(?:-image)?:\s*url\(["']?([^"')]+)["']?\)`)
+	matches = bgRegex.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		if len(match) >= 2 {
+			processFoundLink(match[1], baseURL, foundLinks)
+		}
+	}
+	
+	// Converter map para slice
+	links := make([]string, 0, len(foundLinks))
+	for link := range foundLinks {
+		links = append(links, link)
+	}
+	
+	// Log dos links encontrados (sincronizado)
+	if len(links) > 0 {
+		logMutex.Lock()
+		logger.FInfo(out, formatLog("  Found links: %d\n", len(links)))
+		
+		// Mostrar exemplos (até 5, um por linha, sem emoji)
+		examples := min(5, len(links))
+		if examples > 0 {
+			logger.FInfo(out, "  Examples:\n")
+			for i := 0; i < examples; i++ {
+				logger.FInfo(out, formatLog("    - %s\n", formatURL(links[i], baseURL)))
+			}
+		}
+		logMutex.Unlock()
+	}
+	
+	return links
+}
+
+// Processa um link encontrado e adiciona ao mapa se válido
+func processFoundLink(link, baseURL string, foundLinks map[string]bool) {
+	// Pular links blacklistados
+	if isBlacklisted(link) {
+		return
+	}
+	
+	// Normalizar URL
+	normalizedLink := normalizeURL(link, baseURL)
+	if normalizedLink != "" {
+		foundLinks[normalizedLink] = true
+	}
+}
+
+// Verifica se uma URL está na blacklist
+func isBlacklisted(url string) bool {
+	urlLower := strings.ToLower(url)
+	for _, pattern := range blacklist {
+		if strings.Contains(urlLower, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}
+
+// Formata uma URL para exibição
+func formatURL(fullURL string, baseURL string) string {
+	result := strings.Replace(fullURL, baseURL, "", 1)
+	if result == "" {
+		return "/"
+	}
+	return result
+}
+
+// Verifica se uma slice contém um elemento
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// Função min simples (Go 1.21+)
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Solicita a URL base ao usuário
+func askForUrl() (string, error) {
+	var baseUrl string
+	prompt := &survey.Input{
+		Message: msg.AskForUrl,
+	}
+
+	err := survey.AskOne(prompt, &baseUrl, survey.WithKeepFilter(true), survey.WithStdio(os.Stdin, os.Stderr, os.Stdout))
+	if err != nil {
+		return "", err
+	}
+
+	// Garantir que a URL começa com http:// ou https://
+	if !strings.HasPrefix(baseUrl, "http://") && !strings.HasPrefix(baseUrl, "https://") {
+		baseUrl = "https://" + baseUrl
+	}
+
+	return baseUrl, nil
+}
+
+// Normaliza uma URL relativa para absoluta e remove parâmetros desnecessários (versão melhorada)
+func normalizeURL(link, baseURL string) string {
+	// Pular links vazios ou inválidos
+	link = strings.TrimSpace(link)
+	if link == "" || link == "#" {
+		return ""
+	}
+	
+	// Remover âncoras no final
+	if strings.Contains(link, "#") {
+		link = strings.Split(link, "#")[0]
+		if link == "" {
+			return ""
+		}
+	}
+	
+	var fullURL string
+	
+	// Parse da URL base para ter contexto
+	baseURLParsed, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	
+	// Converter para URL absoluta
+	if strings.HasPrefix(link, "http://") || strings.HasPrefix(link, "https://") {
+		// URL absoluta - verificar se é do mesmo domínio
+		linkParsed, err := url.Parse(link)
+		if err != nil {
+			return ""
+		}
+		if linkParsed.Host != baseURLParsed.Host {
+			return "" // URL externa, ignorar
+		}
+		fullURL = link
+	} else if strings.HasPrefix(link, "//") {
+		// Protocol-relative URL
+		fullURL = baseURLParsed.Scheme + ":" + link
+		linkParsed, err := url.Parse(fullURL)
+		if err != nil {
+			return ""
+		}
+		if linkParsed.Host != baseURLParsed.Host {
+			return "" // URL externa, ignorar
+		}
+	} else if strings.HasPrefix(link, "/") {
+		// URL absoluta no mesmo domínio
+		fullURL = baseURLParsed.Scheme + "://" + baseURLParsed.Host + link
+	} else if strings.HasPrefix(link, "./") {
+		// URL relativa atual
+		link = strings.TrimPrefix(link, "./")
+		basePath := strings.TrimSuffix(baseURLParsed.Path, "/")
+		fullURL = baseURLParsed.Scheme + "://" + baseURLParsed.Host + basePath + "/" + link
+	} else if strings.HasPrefix(link, "../") {
+		// URL relativa pai
+		basePath := baseURLParsed.Path
+		for strings.HasPrefix(link, "../") {
+			link = strings.TrimPrefix(link, "../")
+			// Subir um nível no path
+			if basePath == "/" || basePath == "" {
+				basePath = "/"
+			} else {
+				parts := strings.Split(strings.Trim(basePath, "/"), "/")
+				if len(parts) > 1 {
+					basePath = "/" + strings.Join(parts[:len(parts)-1], "/")
+				} else {
+					basePath = "/"
+				}
+			}
+		}
+		if basePath == "/" {
+			fullURL = baseURLParsed.Scheme + "://" + baseURLParsed.Host + "/" + link
+		} else {
+			fullURL = baseURLParsed.Scheme + "://" + baseURLParsed.Host + basePath + "/" + link
+		}
+	} else {
+		// URL relativa simples (page.html, etc.)
+		basePath := strings.TrimSuffix(baseURLParsed.Path, "/")
+		if basePath == "" {
+			basePath = "/"
+		}
+		// Se o basePath não termina com /, adicionar
+		if !strings.HasSuffix(basePath, "/") {
+			// Se basePath tem extensão, pegar só o diretório
+			if strings.Contains(basePath, ".") {
+				parts := strings.Split(basePath, "/")
+				if len(parts) > 1 {
+					basePath = strings.Join(parts[:len(parts)-1], "/")
+				} else {
+					basePath = "/"
+				}
+			}
+			if basePath != "/" {
+				basePath += "/"
+			}
+		}
+		fullURL = baseURLParsed.Scheme + "://" + baseURLParsed.Host + basePath + link
+	}
+	
+	// Parse da URL final para validação e limpeza
+	parsedURL, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+	
+	// Verificar se o host é válido
+	if parsedURL.Host == "" {
+		return ""
+	}
+	
+	// Remover fragmento
+	parsedURL.Fragment = ""
+	
+	// Manter parâmetros importantes para cache warming
+	paramsToKeep := []string{"id", "category", "product", "page", "search", "q", "query", "filter", "sort", "lang", "locale"}
+	query := parsedURL.Query()
+	newQuery := make(url.Values)
+	
+	for _, param := range paramsToKeep {
+		if value := query.Get(param); value != "" {
+			newQuery.Set(param, value)
+		}
+	}
+	
+	parsedURL.RawQuery = newQuery.Encode()
+	
+	// Retornar URL limpa
+	result := parsedURL.String()
+	
+	// Verificação adicional para evitar URLs malformadas
+	if strings.Contains(result, "xn--") || strings.Contains(result, "@") {
+		return ""
+	}
+	
+	return result
+} 

--- a/pkg/cmd/warmup/warmup.go
+++ b/pkg/cmd/warmup/warmup.go
@@ -77,7 +77,7 @@ func (warmup *WarmupCmd) Run(ctx context.Context, cmd *cobra.Command, f *cmdutil
 		return err
 	}
 
-	logger.FInfo(f.IOStreams.Out, "\n"+msg.WarmupSuccessful)
+	logger.FInfo(f.IOStreams.Out, "\n"+msg.WarmupSuccessful+"\n")
 	return nil
 }
 

--- a/pkg/cmd/warmup/warmup.go
+++ b/pkg/cmd/warmup/warmup.go
@@ -7,15 +7,15 @@ import (
 	msg "github.com/aziontech/azion-cli/messages/warmup"
 	"github.com/aziontech/azion-cli/pkg/cmdutil"
 	"github.com/aziontech/azion-cli/pkg/iostreams"
-	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/aziontech/azion-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 
 var (
-	baseUrl      string
-	maxUrls      int
+	baseUrl       string
+	maxUrls       int
 	maxConcurrent int
-	timeout      int
+	timeout       int
 )
 
 // WarmupCmd defines the command structure
@@ -77,11 +77,15 @@ func (warmup *WarmupCmd) Run(ctx context.Context, cmd *cobra.Command, f *cmdutil
 		return err
 	}
 
-	logger.FInfo(f.IOStreams.Out, "\n"+msg.WarmupSuccessful+"\n")
-	return nil
+	warmupOut := output.GeneralOutput{
+		Msg:   msg.WarmupSuccessful,
+		Out:   f.IOStreams.Out,
+		Flags: f.Flags,
+	}
+	return output.Print(&warmupOut)
 }
 
 // NewCmd creates a new cobra command for warmup
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return NewCobraCmd(NewWarmupCmd(f), f)
-} 
+}

--- a/pkg/cmd/warmup/warmup.go
+++ b/pkg/cmd/warmup/warmup.go
@@ -1,0 +1,87 @@
+package warmup
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	msg "github.com/aziontech/azion-cli/messages/warmup"
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/iostreams"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	baseUrl      string
+	maxUrls      int
+	maxConcurrent int
+	timeout      int
+)
+
+// WarmupCmd defines the command structure
+type WarmupCmd struct {
+	Io          *iostreams.IOStreams
+	WarmupCache func(ctx context.Context, baseUrl string, maxUrls int, maxConcurrent int, timeout int, f *cmdutil.Factory) error
+	AskForUrl   func() (string, error)
+}
+
+// NewWarmupCmd creates a new WarmupCmd instance
+func NewWarmupCmd(f *cmdutil.Factory) *WarmupCmd {
+	return &WarmupCmd{
+		Io:          f.IOStreams,
+		WarmupCache: warmupCache,
+		AskForUrl:   askForUrl,
+	}
+}
+
+// NewCobraCmd creates a new cobra command for warmup
+func NewCobraCmd(warmup *WarmupCmd, f *cmdutil.Factory) *cobra.Command {
+	cobraCmd := &cobra.Command{
+		Use:           msg.Usage,
+		Short:         msg.ShortDescription,
+		Long:          msg.LongDescription,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Example: heredoc.Doc(`
+        $ azion warmup --url "https://example.com"
+        $ azion warmup --url "https://example.com/products"
+        $ azion warmup --url "https://example.com/blog" --max-urls 500 --max-concurrent 5 --timeout 10000
+        `),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := context.Background()
+			return warmup.Run(ctx, cmd, f)
+		},
+	}
+
+	cobraCmd.Flags().StringVar(&baseUrl, "url", "", msg.FlagUrl)
+	cobraCmd.Flags().IntVar(&maxUrls, "max-urls", 1500, msg.FlagMaxUrls)
+	cobraCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 2, msg.FlagMaxConcurrent)
+	cobraCmd.Flags().IntVar(&timeout, "timeout", 8000, msg.FlagTimeout)
+	cobraCmd.Flags().BoolP("help", "h", false, msg.FlagHelp)
+
+	return cobraCmd
+}
+
+// Run executes the warmup command
+func (warmup *WarmupCmd) Run(ctx context.Context, cmd *cobra.Command, f *cmdutil.Factory) error {
+	if !cmd.Flags().Changed("url") {
+		url, err := warmup.AskForUrl()
+		if err != nil {
+			return err
+		}
+		baseUrl = url
+	}
+
+	err := warmup.WarmupCache(ctx, baseUrl, maxUrls, maxConcurrent, timeout, f)
+	if err != nil {
+		return err
+	}
+
+	logger.FInfo(f.IOStreams.Out, "\n"+msg.WarmupSuccessful)
+	return nil
+}
+
+// NewCmd creates a new cobra command for warmup
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	return NewCobraCmd(NewWarmupCmd(f), f)
+} 

--- a/pkg/cmd/warmup/warmup_test.go
+++ b/pkg/cmd/warmup/warmup_test.go
@@ -1,0 +1,276 @@
+package warmup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aziontech/azion-cli/pkg/cmdutil"
+	"github.com/aziontech/azion-cli/pkg/httpmock"
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/aziontech/azion-cli/pkg/testutils"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewCmd(t *testing.T) {
+	logger.New(zapcore.DebugLevel)
+	mock := &httpmock.Registry{}
+	f, _, _ := testutils.NewFactory(mock)
+	cmd := NewCmd(f)
+
+	assert.Equal(t, cmd.Use, "warmup")
+	assert.Equal(t, cmd.Short, "Preload URLs into edge cache")
+	assert.NotEmpty(t, cmd.Example)
+}
+
+func TestWarmupCmd_Run(t *testing.T) {
+	logger.New(zapcore.DebugLevel)
+	
+	tests := []struct {
+		name      string
+		mock      func(*WarmupCmd)
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name: "successfully warmup cache",
+			mock: func(w *WarmupCmd) {
+				w.WarmupCache = func(ctx context.Context, baseUrl string, maxUrls int, maxConcurrent int, timeout int, f *cmdutil.Factory) error {
+					return nil
+				}
+				w.AskForUrl = func() (string, error) {
+					return "https://example.com", nil
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &httpmock.Registry{}
+			f, stdout, _ := testutils.NewFactory(mock)
+
+			cmd := &cobra.Command{}
+			baseUrl = "https://example.com"
+
+			warmupCmd := &WarmupCmd{
+				Io: f.IOStreams,
+			}
+
+			tt.mock(warmupCmd)
+
+			err := warmupCmd.Run(context.Background(), cmd, f)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, stdout.String(), "Cache warming completed successfully")
+			}
+		})
+	}
+}
+
+func TestWarmupCache(t *testing.T) {
+	logger.New(zapcore.DebugLevel)
+	
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.html")
+	err := os.WriteFile(testFile, []byte(`<html><body><a href="/page1">Page 1</a></body></html>`), 0644)
+	assert.NoError(t, err)
+
+	mock := &httpmock.Registry{}
+	f, _, _ := testutils.NewFactory(mock)
+
+	err = warmupCache(context.Background(), "https://example.com", 10, 2, 30, f)
+	assert.NoError(t, err)
+}
+
+func TestExtractLinks(t *testing.T) {
+	logger.New(zapcore.DebugLevel)
+	
+	html := `<html><head>
+		<link rel="stylesheet" href="/styles/main.css">
+		<script src="/js/app.js"></script>
+		<link rel="canonical" href="https://example.com/canonical-page">
+		<meta http-equiv="refresh" content="5; url=/redirect-page">
+		<link rel="icon" href="/favicon.ico">
+		<style>
+			.hero { background-image: url('/images/hero-bg.jpg'); }
+		</style>
+	</head><body>
+		<a href="/page1">Page 1</a>
+		<a href="https://example.com/page2">Page 2</a>
+		<a href="mailto:test@example.com">Email</a>
+		<a href="/test.pdf">PDF</a>
+		<a href="./relative-page">Relative</a>
+		<a href="../parent-page">Parent</a>
+		<img src="/images/logo.png" alt="Logo">
+		<img src="https://example.com/images/banner.jpg" alt="Banner">
+		<form action="/search" method="post">
+			<input type="submit" value="Search">
+		</form>
+	</body></html>`
+
+	mock := &httpmock.Registry{}
+	f, _, _ := testutils.NewFactory(mock)
+
+	var logMutex sync.Mutex
+	links := extractLinks(html, "https://example.com", f.IOStreams.Out, &logMutex)
+	
+	// Verify traditional links
+	assert.Contains(t, links, "https://example.com/page1")
+	assert.Contains(t, links, "https://example.com/page2")
+	
+	// Verify CSS/JS resources
+	assert.Contains(t, links, "https://example.com/styles/main.css")
+	assert.Contains(t, links, "https://example.com/js/app.js")
+	
+	// Verify forms
+	assert.Contains(t, links, "https://example.com/search")
+	
+	// Verify canonical
+	assert.Contains(t, links, "https://example.com/canonical-page")
+	
+	// Verify meta refresh
+	assert.Contains(t, links, "https://example.com/redirect-page")
+	
+	// Verify relative URLs
+	assert.Contains(t, links, "https://example.com/relative-page")
+	assert.Contains(t, links, "https://example.com/parent-page")
+	
+	// Verify images (new functionality)
+	assert.Contains(t, links, "https://example.com/images/logo.png")
+	assert.Contains(t, links, "https://example.com/images/banner.jpg")
+	
+	// Verify icons
+	assert.Contains(t, links, "https://example.com/favicon.ico")
+	
+	// Verify background images
+	assert.Contains(t, links, "https://example.com/images/hero-bg.jpg")
+	
+	// Verify blacklist still works
+	assert.NotContains(t, links, "mailto:test@example.com")
+	assert.NotContains(t, links, "https://example.com/test.pdf")
+}
+
+func TestIsBlacklisted(t *testing.T) {
+	tests := []struct {
+		url        string
+		blacklisted bool
+	}{
+		// Normal pages - should pass
+		{"https://example.com/page.html", false},
+		{"https://example.com/normal-page", false},
+		
+		// Images - should now pass (no longer in blacklist)
+		{"https://example.com/image.jpg", false},
+		{"https://example.com/photo.png", false},
+		{"https://example.com/icon.svg", false},
+		
+		// CSS and JS - should pass
+		{"https://example.com/style.css", false},
+		{"https://example.com/script.js", false},
+		
+		// Documents - should be blocked
+		{"https://example.com/file.pdf", true},
+		{"https://example.com/doc.docx", true},
+		
+		// Videos/audios - should be blocked
+		{"https://example.com/video.mp4", true},
+		{"https://example.com/audio.mp3", true},
+		
+		// Special links - should be blocked
+		{"mailto:test@example.com", true},
+		{"tel:+1234567890", true},
+		{"javascript:void(0)", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			result := isBlacklisted(tt.url)
+			assert.Equal(t, tt.blacklisted, result)
+		})
+	}
+}
+
+func TestFormatURL(t *testing.T) {
+	tests := []struct {
+		fullURL  string
+		baseURL  string
+		expected string
+	}{
+		{"https://example.com/page1", "https://example.com", "/page1"},
+		{"https://example.com/", "https://example.com", "/"},
+		{"https://other.com/page", "https://example.com", "https://other.com/page"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fullURL, func(t *testing.T) {
+			result := formatURL(tt.fullURL, tt.baseURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		link     string
+		baseURL  string
+		expected string
+	}{
+		// Absolute URLs
+		{"/page1", "https://example.com", "https://example.com/page1"},
+		{"https://example.com/page2", "https://example.com", "https://example.com/page2"},
+		
+		// Relative URLs
+		{"./page3", "https://example.com/dir/", "https://example.com/dir/page3"},
+		{"../page4", "https://example.com/dir/subdir/", "https://example.com/dir/page4"},
+		{"page5.html", "https://example.com/dir/", "https://example.com/dir/page5.html"},
+		
+		// Protocol-relative
+		{"//example.com/page6", "https://example.com", "https://example.com/page6"},
+		
+		// URLs with anchors (should be removed)
+		{"/page7#section", "https://example.com", "https://example.com/page7"},
+		
+		// External URLs (should be ignored)
+		{"https://other.com/page", "https://example.com", ""},
+		{"//other.com/page", "https://example.com", ""},
+		
+		// Empty or invalid URLs
+		{"", "https://example.com", ""},
+		{"#", "https://example.com", ""},
+		{"#section", "https://example.com", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.link, func(t *testing.T) {
+			result := normalizeURL(tt.link, tt.baseURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProcessFoundLink(t *testing.T) {
+	foundLinks := make(map[string]bool)
+	
+	// Valid link
+	processFoundLink("/valid-page", "https://example.com", foundLinks)
+	assert.Contains(t, foundLinks, "https://example.com/valid-page")
+	
+	// Blacklisted link
+	processFoundLink("/document.pdf", "https://example.com", foundLinks)
+	assert.NotContains(t, foundLinks, "https://example.com/document.pdf")
+	
+	// External link
+	processFoundLink("https://other.com/page", "https://example.com", foundLinks)
+	assert.NotContains(t, foundLinks, "https://other.com/page")
+} 

--- a/pkg/cmd/warmup/warmup_test.go
+++ b/pkg/cmd/warmup/warmup_test.go
@@ -29,7 +29,7 @@ func TestNewCmd(t *testing.T) {
 
 func TestWarmupCmd_Run(t *testing.T) {
 	logger.New(zapcore.DebugLevel)
-	
+
 	tests := []struct {
 		name      string
 		mock      func(*WarmupCmd)
@@ -72,7 +72,7 @@ func TestWarmupCmd_Run(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				assert.Contains(t, stdout.String(), "Cache warming completed successfully")
+				assert.Contains(t, stdout.String(), "Cache warming completed successfully!")
 			}
 		})
 	}
@@ -80,7 +80,7 @@ func TestWarmupCmd_Run(t *testing.T) {
 
 func TestWarmupCache(t *testing.T) {
 	logger.New(zapcore.DebugLevel)
-	
+
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "test.html")
 	err := os.WriteFile(testFile, []byte(`<html><body><a href="/page1">Page 1</a></body></html>`), 0644)
@@ -95,7 +95,7 @@ func TestWarmupCache(t *testing.T) {
 
 func TestExtractLinks(t *testing.T) {
 	logger.New(zapcore.DebugLevel)
-	
+
 	html := `<html><head>
 		<link rel="stylesheet" href="/styles/main.css">
 		<script src="/js/app.js"></script>
@@ -124,38 +124,38 @@ func TestExtractLinks(t *testing.T) {
 
 	var logMutex sync.Mutex
 	links := extractLinks(html, "https://example.com", f.IOStreams.Out, &logMutex)
-	
+
 	// Verify traditional links
 	assert.Contains(t, links, "https://example.com/page1")
 	assert.Contains(t, links, "https://example.com/page2")
-	
+
 	// Verify CSS/JS resources
 	assert.Contains(t, links, "https://example.com/styles/main.css")
 	assert.Contains(t, links, "https://example.com/js/app.js")
-	
+
 	// Verify forms
 	assert.Contains(t, links, "https://example.com/search")
-	
+
 	// Verify canonical
 	assert.Contains(t, links, "https://example.com/canonical-page")
-	
+
 	// Verify meta refresh
 	assert.Contains(t, links, "https://example.com/redirect-page")
-	
+
 	// Verify relative URLs
 	assert.Contains(t, links, "https://example.com/relative-page")
 	assert.Contains(t, links, "https://example.com/parent-page")
-	
+
 	// Verify images (new functionality)
 	assert.Contains(t, links, "https://example.com/images/logo.png")
 	assert.Contains(t, links, "https://example.com/images/banner.jpg")
-	
+
 	// Verify icons
 	assert.Contains(t, links, "https://example.com/favicon.ico")
-	
+
 	// Verify background images
 	assert.Contains(t, links, "https://example.com/images/hero-bg.jpg")
-	
+
 	// Verify blacklist still works
 	assert.NotContains(t, links, "mailto:test@example.com")
 	assert.NotContains(t, links, "https://example.com/test.pdf")
@@ -163,30 +163,30 @@ func TestExtractLinks(t *testing.T) {
 
 func TestIsBlacklisted(t *testing.T) {
 	tests := []struct {
-		url        string
+		url         string
 		blacklisted bool
 	}{
 		// Normal pages - should pass
 		{"https://example.com/page.html", false},
 		{"https://example.com/normal-page", false},
-		
+
 		// Images - should now pass (no longer in blacklist)
 		{"https://example.com/image.jpg", false},
 		{"https://example.com/photo.png", false},
 		{"https://example.com/icon.svg", false},
-		
+
 		// CSS and JS - should pass
 		{"https://example.com/style.css", false},
 		{"https://example.com/script.js", false},
-		
+
 		// Documents - should be blocked
 		{"https://example.com/file.pdf", true},
 		{"https://example.com/doc.docx", true},
-		
+
 		// Videos/audios - should be blocked
 		{"https://example.com/video.mp4", true},
 		{"https://example.com/audio.mp3", true},
-		
+
 		// Special links - should be blocked
 		{"mailto:test@example.com", true},
 		{"tel:+1234567890", true},
@@ -229,22 +229,22 @@ func TestNormalizeURL(t *testing.T) {
 		// Absolute URLs
 		{"/page1", "https://example.com", "https://example.com/page1"},
 		{"https://example.com/page2", "https://example.com", "https://example.com/page2"},
-		
+
 		// Relative URLs
 		{"./page3", "https://example.com/dir/", "https://example.com/dir/page3"},
 		{"../page4", "https://example.com/dir/subdir/", "https://example.com/dir/page4"},
 		{"page5.html", "https://example.com/dir/", "https://example.com/dir/page5.html"},
-		
+
 		// Protocol-relative
 		{"//example.com/page6", "https://example.com", "https://example.com/page6"},
-		
+
 		// URLs with anchors (should be removed)
 		{"/page7#section", "https://example.com", "https://example.com/page7"},
-		
+
 		// External URLs (should be ignored)
 		{"https://other.com/page", "https://example.com", ""},
 		{"//other.com/page", "https://example.com", ""},
-		
+
 		// Empty or invalid URLs
 		{"", "https://example.com", ""},
 		{"#", "https://example.com", ""},
@@ -261,16 +261,16 @@ func TestNormalizeURL(t *testing.T) {
 
 func TestProcessFoundLink(t *testing.T) {
 	foundLinks := make(map[string]bool)
-	
+
 	// Valid link
 	processFoundLink("/valid-page", "https://example.com", foundLinks)
 	assert.Contains(t, foundLinks, "https://example.com/valid-page")
-	
+
 	// Blacklisted link
 	processFoundLink("/document.pdf", "https://example.com", foundLinks)
 	assert.NotContains(t, foundLinks, "https://example.com/document.pdf")
-	
+
 	// External link
 	processFoundLink("https://other.com/page", "https://example.com", foundLinks)
 	assert.NotContains(t, foundLinks, "https://other.com/page")
-} 
+}


### PR DESCRIPTION
## Add warmup command for cache preloading

Implements a new CLI command to systematically crawl and preload URLs into the edge cache.

### Features
- **Recursive URL crawling** starting from a base URL
- **Concurrent processing** with configurable limits
- **Smart URL filtering** with blacklist for unwanted file types
- **Progress tracking** and detailed statistics
- **Error handling** with failed URL reporting

### Usage
```bash
azion warmup --url "https://example.com"
azion warmup --url "https://example.com" --max-urls 500 --max-concurrent 5 --timeout 10000
```

### Arguments
- `--url`: Base URL to start cache warming (required)
- `--max-urls`: Maximum URLs to process (default: 1500)
- `--max-concurrent`: Concurrent requests limit (default: 2)
- `--timeout`: Request timeout in milliseconds (default: 8000)

### Implementation
- Follows existing CLI patterns and project structure
- Includes comprehensive unit tests and fixtures
- Provides clean, organized output with completion statistics
- 
https://github.com/user-attachments/assets/09bce850-892e-44ff-8e35-1b6693f68ce8

