### PR TITLE
chore: show update message 24 hours after publishing

### DIFF
--- a/pkg/cmd/root/pre_command.go
+++ b/pkg/cmd/root/pre_command.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/aziontech/azion-cli/pkg/github"
+	"go.uber.org/zap"
 
 	msg "github.com/aziontech/azion-cli/messages/root"
 	"github.com/aziontech/azion-cli/pkg/cmd/version"
@@ -133,13 +134,14 @@ func checkForUpdateAndMetrics(cVersion string, f *cmdutil.Factory, settings *tok
 
 	git := github.NewGithub()
 
-	tagName, err := git.GetVersionGitHub("azion")
+	tagName, publishedAt, err := git.GetVersionGitHub("azion")
 	if err != nil {
 		return err
 	}
 
 	logger.Debug("Current version: " + cVersion)
 	logger.Debug("Latest version: " + tagName)
+	logger.Debug("Published at: " + publishedAt)
 
 	latestVersion, err := format(tagName)
 	if err != nil {
@@ -150,13 +152,24 @@ func checkForUpdateAndMetrics(cVersion string, f *cmdutil.Factory, settings *tok
 		return err
 	}
 
-	logger.Debug("Formatted current version: " + fmt.Sprint(currentVersion))
-	logger.Debug("Formatted latest version: " + fmt.Sprint(latestVersion))
-
 	if latestVersion > currentVersion {
-		err := showUpdateMessage(f, tagName)
+		// Parse the published_at date
+		publishedTime, err := time.Parse(time.RFC3339, publishedAt)
 		if err != nil {
-			return err
+			logger.Debug("Failed to parse published_at date", zap.Error(err))
+			// If we can't parse the date, fall back to showing the update message
+			err := showUpdateMessage(f, tagName)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Only show update message if at least 24 hours have passed since publishing
+			if time.Since(publishedTime) >= 24*time.Hour {
+				err := showUpdateMessage(f, tagName)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/pkg/cmd/root/update_check_test.go
+++ b/pkg/cmd/root/update_check_test.go
@@ -1,0 +1,89 @@
+package root
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aziontech/azion-cli/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+// TestTimeComparisonLogic tests the core logic of comparing publish time with current time
+// to determine if an update message should be shown
+func TestTimeComparisonLogic(t *testing.T) {
+	logger.New(zapcore.DebugLevel)
+
+	tests := []struct {
+		name             string
+		publishedAt      time.Time
+		shouldShowUpdate bool
+	}{
+		{
+			name:             "Less than 24 hours since publishing",
+			publishedAt:      time.Now().Add(-23 * time.Hour),
+			shouldShowUpdate: false,
+		},
+		{
+			name:             "Exactly 24 hours since publishing",
+			publishedAt:      time.Now().Add(-24 * time.Hour),
+			shouldShowUpdate: true,
+		},
+		{
+			name:             "More than 24 hours since publishing",
+			publishedAt:      time.Now().Add(-25 * time.Hour),
+			shouldShowUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the core logic directly
+			actualShouldShow := time.Since(tt.publishedAt) >= 24*time.Hour
+			
+			// Assert whether update message should be shown as expected
+			assert.Equal(t, tt.shouldShowUpdate, actualShouldShow, 
+				"Expected shouldShowUpdate to be %v, but got %v for publish time %v", 
+				tt.shouldShowUpdate, actualShouldShow, tt.publishedAt)
+		})
+	}
+}
+
+// TestParsePublishedAtDate tests the parsing of the published_at date from GitHub API
+func TestParsePublishedAtDate(t *testing.T) {
+	tests := []struct {
+		name        string
+		publishedAt string
+		isValid     bool
+	}{
+		{
+			name:        "Valid RFC3339 date",
+			publishedAt: "2025-09-12T19:15:10Z",
+			isValid:     true,
+		},
+		{
+			name:        "Invalid date format",
+			publishedAt: "2025/09/12 19:15:10",
+			isValid:     false,
+		},
+		{
+			name:        "Empty date",
+			publishedAt: "",
+			isValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Try to parse the date
+			_, err := time.Parse(time.RFC3339, tt.publishedAt)
+			
+			// Check if parsing was successful as expected
+			if tt.isValid {
+				assert.NoError(t, err, "Expected valid date but got error: %v", err)
+			} else {
+				assert.Error(t, err, "Expected error for invalid date but got none")
+			}
+		})
+	}
+}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -37,7 +37,7 @@ func TestGetVersionGitHub(t *testing.T) {
 			repoName:   "azion-cli",
 			wantTag:    "1.30.0",
 			statusCode: http.StatusOK,
-			response:   `{"tag_name": "1.30.0"}`,
+			response:   `{"tag_name": "1.30.0", "published_at": "2025-09-12T19:15:10Z"}`,
 			wantErr:    false,
 		},
 	}
@@ -58,11 +58,11 @@ func TestGetVersionGitHub(t *testing.T) {
 			defer func() { ApiURL = oldURL }()
 
 			gh := NewGithub()
-			gh.GetVersionGitHub = func(name string) (string, error) {
-				return tt.wantTag, nil
+			gh.GetVersionGitHub = func(name string) (string, string, error) {
+				return tt.wantTag, "2025-09-12T19:15:10Z", nil
 			}
 
-			gotTag, err := gh.GetVersionGitHub(tt.repoName)
+			gotTag, _, err := gh.GetVersionGitHub(tt.repoName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetVersionGitHub() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/metric/count.go
+++ b/pkg/metric/count.go
@@ -62,7 +62,7 @@ func TotalCommandsCount(cmd cmdutil.Command, commandName string, executionTime f
 
 	git := github.NewGithub()
 
-	tagName, err := git.GetVersionGitHub("bundler")
+	tagName, _, err := git.GetVersionGitHub("bundler")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- The previous way was causing confusion due to showing an update message before homebrew updated with the new version. The new way will only show the update message after 24 hours of the new version being published.